### PR TITLE
Fix up WinRM wrapping on SSPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.2 - TBD
+
+* Fix up WinRM wrapping on SSPI
+
 ## 0.1.1 - 2020-09-01
 
 * Include the cython files in the built sdist

--- a/spnego/_version.py
+++ b/spnego/_version.py
@@ -4,4 +4,4 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type  # noqa (fixes E402 for the imports below)
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'

--- a/spnego/sspi.py
+++ b/spnego/sspi.py
@@ -221,11 +221,10 @@ class SSPIProxy(ContextProxy):
         return IOVWrapResult(buffers=_create_iov_result(iov_buffer), encrypted=encrypt)
 
     def wrap_winrm(self, data):
-        iov = self.wrap_iov([BufferType.header, data, BufferType.padding]).buffers
+        iov = self.wrap_iov([BufferType.header, data]).buffers
         enc_data = iov[1].data
-        padding = iov[2].data or b""
 
-        return WinRMWrapResult(header=iov[0].data, data=enc_data + padding, padding_length=len(padding))
+        return WinRMWrapResult(header=iov[0].data, data=enc_data, padding_length=0)
 
     def unwrap(self, data):
         res = self.unwrap_iov([(BufferType.stream, data), BufferType.data])
@@ -240,7 +239,7 @@ class SSPIProxy(ContextProxy):
         return IOVUnwrapResult(buffers=_create_iov_result(iov_buffer), encrypted=encrypted, qop=qop)
 
     def unwrap_winrm(self, header, data):
-        iov = self.unwrap_iov([(BufferType.header, header), data, BufferType.padding]).buffers
+        iov = self.unwrap_iov([(BufferType.header, header), data]).buffers
         return iov[1].data
 
     @wrap_system_error(NativeError, "Signing message")


### PR DESCRIPTION
WSMV when using SSPI does not actually provide a padding buffer to the SSPI call so we should not do so ourselves. There has been a long internal conversation with the protocol team for WSMV and they have confirmed that when it calls SSPI it does it with the headers

1. `SECBUFFER_TOKEN`
2. `SECBUFFER_DATA`

This is cause of the weird hacks in [gssapi](https://github.com/jborean93/pyspnego/blob/04c9d183778e0b8d7fa7bfe170d7b405d5e496ae/spnego/gss.py#L493-L515) to deal with RC4 when the padding is expected by GSSAPI but SSPI does not provide it in this protocol. So while we must still supply the padding buffer for GSSAPI we can replicate the exact behaviour when running on Windows. I'm not sure how I tested this before but I can confirm that this works with both AES and RC4 on Windows.

Fixes https://github.com/jborean93/pypsrp/issues/90