### PR TITLE
Fix up request-mic for Negotiate auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
 
+## 0.1.4 - TBD
+
+* Only send `negState: request-mic` for the first reply from an acceptor for Negotiate auth.
+  * Strict interpretations of SPNEGO will fail if the initiator sends this state as it is against the RFC.
+
 ## 0.1.3 - 2020-10-29
 
-* Added Python 3.9 to CI and build Windows wheel for this versoin
+* Added Python 3.9 to CI and build Windows wheel for this version
 
 ## 0.1.2 - 2020-10-01
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,6 +49,7 @@ stages:
         versionSpec: $(python.version)
 
     - script: |
+        sudo apt-get update
         sudo apt-get install -y \
           gcc \
           gss-ntlmssp \

--- a/spnego/_version.py
+++ b/spnego/_version.py
@@ -4,4 +4,4 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type  # noqa (fixes E402 for the imports below)
 
-__version__ = '0.1.3'
+__version__ = '0.1.4'


### PR DESCRIPTION
The [RFC for SPNEGO](https://www.rfc-editor.org/rfc/rfc4178.html#section-4.2.1) states that `negState: request-mic` should only be sent in the first reply from the acceptor

> The sender indicates that the exchange of MIC tokens, as described in Section 5, will be REQUIRED if per-message integrity services are available on the mechanism context to be established.  This value SHALL only be present in the first reply from the target.

It seems like GSSAPI and SSPI are lenient in that it doesn't validate this requirement so it was never an issue for those implementations but others may not be the same. This fixes the logic to conform to the RFC and work with implementations that enforce this.

This issue was found in https://github.com/jborean93/smbprotocol/issues/61 where the NetApp GSSAPI implementation was failing because the NTLM Authentication message was sending `request-mic` in the `NegTokenResp` when it was only expecting `accept-incomplete` or `accept-complete`.