### PR TITLE
Add workstation override to match gss-ntlmssp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.5 - TBD
+
+* Respect `NETBIOS_COMPUTER_NAME` when getting the workstation name for NTLM tokens. This matches the behaviour of `gss-ntlmssp` to ensure a consistent approach.
+
 ## 0.1.4 - 2020-12-02
 
 * Only send `negState: request-mic` for the first reply from an acceptor for Negotiate auth.

--- a/spnego/_version.py
+++ b/spnego/_version.py
@@ -4,4 +4,4 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type  # noqa (fixes E402 for the imports below)
 
-__version__ = '0.1.4'
+__version__ = '0.1.5'

--- a/spnego/ntlm.py
+++ b/spnego/ntlm.py
@@ -179,11 +179,11 @@ def _get_credential(store, domain=None, username=None):
 
 def _get_workstation():  # type: () -> Optional[str]
     """Get the current workstation name.
-    
+
     This gets the current workstation name that respects `NETBIOS_COMPUTER_NAME`. The env var is used by the library
     that gss-ntlmssp calls and makes sure that this Python implementation is a closer in its behaviour.
 
-    Returns:    
+    Returns:
         Optional[str]: The workstation to supply in the NTLM authentication message or None.
     """
     if 'NETBIOS_COMPUTER_NAME' in os.environ:
@@ -191,7 +191,7 @@ def _get_workstation():  # type: () -> Optional[str]
 
     else:
         workstation = to_text(socket.gethostname()).upper()
-        
+
     # An empty workstation should be None so we don't set it in the message.
     return workstation if workstation else None
 

--- a/spnego/ntlm.py
+++ b/spnego/ntlm.py
@@ -190,10 +190,10 @@ def _get_workstation():  # type: () -> Optional[str]
         workstation = os.environ['NETBIOS_COMPUTER_NAME']
 
     else:
-        workstation = to_text(socket.gethostname()).upper()
+        workstation = socket.gethostname().upper()
 
     # An empty workstation should be None so we don't set it in the message.
-    return workstation if workstation else None
+    return to_text(workstation) if workstation else None
 
 
 class _NTLMCredential:

--- a/tests/test_ntlm.py
+++ b/tests/test_ntlm.py
@@ -257,7 +257,7 @@ def test_ntlm_workstation_override(env_var, expected, ntlm_cred, monkeypatch):
 
     c = spnego.client(ntlm_cred[0], ntlm_cred[1], hostname=socket.gethostname(),
                       options=spnego.NegotiateOptions.use_ntlm, protocol='ntlm')
-    
+
     b_negotiate = c.step()
     negotiate = Negotiate.unpack(b_negotiate)
 
@@ -275,7 +275,7 @@ def test_ntlm_workstation_override(env_var, expected, ntlm_cred, monkeypatch):
 
     version = Version(10, 0, 0, 1)
     challenge = Challenge(flags, server_challenge, target_name=target_name, target_info=target_info, version=version)
-    
+
     b_auth = c.step(challenge.pack())
     auth = Authenticate.unpack(b_auth)
 
@@ -314,7 +314,7 @@ def test_ntlm_custom_time(include_time, expected, ntlm_cred, mocker, monkeypatch
     mock_now = mocker.MagicMock()
     mock_now.side_effect = FileTime.now
     monkeypatch.setattr(FileTime, 'now', mock_now)
-    
+
     c.step(challenge.pack())
     assert c.complete
     assert mock_now.call_count == expected

--- a/tests/test_ntlm.py
+++ b/tests/test_ntlm.py
@@ -19,6 +19,13 @@ import spnego.sspi
 
 from spnego._ntlm_raw.messages import (
     Authenticate,
+    AvId,
+    Challenge,
+    FileTime,
+    Negotiate,
+    NegotiateFlags,
+    TargetInfo,
+    Version,
 )
 
 from spnego._text import (
@@ -237,6 +244,80 @@ def test_ntlm_bad_mic(ntlm_cred):
 
     with pytest.raises(InvalidTokenError, match="Invalid MIC in NTLM authentication message"):
         s.step(auth.tobytes())
+
+
+@pytest.mark.parametrize('env_var, expected', [
+    (None, to_text(socket.gethostname()).upper()),
+    ('', None),
+    ('custom', 'custom'),
+])
+def test_ntlm_workstation_override(env_var, expected, ntlm_cred, monkeypatch):
+    if env_var is not None:
+        monkeypatch.setenv('NETBIOS_COMPUTER_NAME', env_var)
+
+    c = spnego.client(ntlm_cred[0], ntlm_cred[1], hostname=socket.gethostname(),
+                      options=spnego.NegotiateOptions.use_ntlm, protocol='ntlm')
+    
+    b_negotiate = c.step()
+    negotiate = Negotiate.unpack(b_negotiate)
+
+    flags = negotiate.flags | NegotiateFlags.request_target | NegotiateFlags.ntlm | \
+        NegotiateFlags.always_sign | NegotiateFlags.target_info | NegotiateFlags.target_type_server
+
+    server_challenge = os.urandom(8)
+    target_name = to_text(socket.gethostname()).upper()
+
+    target_info = TargetInfo()
+    target_info[AvId.nb_computer_name] = target_name
+    target_info[AvId.nb_domain_name] = u"WORKSTATION"
+    target_info[AvId.dns_computer_name] = to_text(socket.getfqdn())
+    target_info[AvId.timestamp] = FileTime.now()
+
+    version = Version(10, 0, 0, 1)
+    challenge = Challenge(flags, server_challenge, target_name=target_name, target_info=target_info, version=version)
+    
+    b_auth = c.step(challenge.pack())
+    auth = Authenticate.unpack(b_auth)
+
+    assert auth.workstation == expected
+
+
+@pytest.mark.parametrize('include_time, expected', [
+    # If the challenge didn't contain the time then the client should generate it's own otherwise it uses the challenge
+    # time.
+    (True, 0),
+    (False, 1),
+])
+def test_ntlm_custom_time(include_time, expected, ntlm_cred, mocker, monkeypatch):
+    c = spnego.client(ntlm_cred[0], ntlm_cred[1], hostname=socket.gethostname(),
+                      options=spnego.NegotiateOptions.use_ntlm, protocol='ntlm')
+
+    b_negotiate = c.step()
+    negotiate = Negotiate.unpack(b_negotiate)
+
+    flags = negotiate.flags | NegotiateFlags.request_target | NegotiateFlags.ntlm | \
+        NegotiateFlags.always_sign | NegotiateFlags.target_info | NegotiateFlags.target_type_server
+
+    server_challenge = os.urandom(8)
+    target_name = to_text(socket.gethostname()).upper()
+
+    target_info = TargetInfo()
+    target_info[AvId.nb_computer_name] = target_name
+    target_info[AvId.nb_domain_name] = u"WORKSTATION"
+    target_info[AvId.dns_computer_name] = to_text(socket.getfqdn())
+
+    if include_time:
+        target_info[AvId.timestamp] = FileTime.now()
+
+    challenge = Challenge(flags, server_challenge, target_name=target_name, target_info=target_info)
+
+    mock_now = mocker.MagicMock()
+    mock_now.side_effect = FileTime.now
+    monkeypatch.setattr(FileTime, 'now', mock_now)
+    
+    c.step(challenge.pack())
+    assert c.complete
+    assert mock_now.call_count == expected
 
 
 def test_ntlm_no_key_exch(ntlm_cred):


### PR DESCRIPTION
There may be some edge cases where a user wants to blank out the workstation field in an NTLM exchange. The `gss-ntlmssp` library uses the env var `NETBIOS_COMPUTER_NAME` as a way to override the value and to ensure consistency between that library and the Python one here we will also use that env var.