### PR TITLE
Fix enum usage for Python 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.6 - TBD
+
+* Change enum type of `iov.BufferType` to `IntEnum` to fix load on Python 3.10 - https://github.com/jborean93/pyspnego/issues/10
+
 ## 0.1.5 - 2021-01-12
 
 * Respect `NETBIOS_COMPUTER_NAME` when getting the workstation name for NTLM tokens. This matches the behaviour of `gss-ntlmssp` to ensure a consistent approach.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,15 +144,16 @@ stages:
         versionSpec: $(python.version)
         architecture: $(python.arch)
 
-    - script: |
+    - powershell: |
         $msiPath = Join-Path ([IO.Path]::GetTempPath()) 'VSForPython27.msi'
         [Net.WebClient]::new().DownloadFile('https://raw.githubusercontent.com/jborean93/VCPython27/master/VCForPython27.msi', $msiPath)
         Start-Process -FilePath msiexec.exe -Wait -ArgumentList @(
             '/i',
             $msiPath,
             '/qn',
-            '/norestart',
+            '/norestart'
         )
+      errorActionPreference: stop
       displayName: Install Python C++ build tools
       condition: eq(variables['python.version'], '2.7')
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,14 @@ stages:
         architecture: $(python.arch)
 
     - script: |
-        choco.exe install vcpython27 --yes --no-progress
+        $msiPath = Join-Path ([IO.Path]::GetTempPath()) 'VSForPython27.msi'
+        [Net.WebClient]::new().DownloadFile('https://raw.githubusercontent.com/jborean93/VCPython27/master/VCForPython27.msi', $msiPath)
+        Start-Process -FilePath msiexec.exe -Wait -ArgumentList @(
+            '/i',
+            $msiPath,
+            '/qn',
+            '/norestart',
+        )
       displayName: Install Python C++ build tools
       condition: eq(variables['python.version'], '2.7')
 

--- a/spnego/iov.py
+++ b/spnego/iov.py
@@ -7,11 +7,11 @@ __metaclass__ = type  # noqa (fixes E402 for the imports below)
 import collections
 
 from spnego._compat import (
-    IntFlag,
+    IntEnum,
 )
 
 
-class BufferType(IntFlag):
+class BufferType(IntEnum):
     """Buffer types to use for an IOVBuffer type.
 
     These are the IOVBuffer type flags that can be set for an IOVBuffer. The keys are a generified name for the


### PR DESCRIPTION
This type class should really be an `IntEnum` as it's meant to represent a single value.

Fixes https://github.com/jborean93/pyspnego/issues/10