### PR TITLE
Fix SPNEGO mechListMIC logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added support for CredSSP authentication using `protocol='credssp'`
 * Use Kerberos API to acquire Kerberos credential to get a forwardable token in a thread safe manner
 * Fix default credential logic when no username is provided based on GSSAPI rules rather than just the default principal - https://github.com/jborean93/pyspnego/issues/15
+* Ignore SPNEGO `mechListMIC` if it contains the same value as the `responseToken` due to an old Windows SPNEGO logic bug - https://github.com/krb5/krb5/blob/3f5a348287646d65700854650fe668b9c4249013/src/lib/gssapi/spnego/spnego_mech.c#L3734-L3744
 
 ## 0.1.6 - 2021-05-07
 

--- a/spnego/negotiate.py
+++ b/spnego/negotiate.py
@@ -193,6 +193,12 @@ class NegotiateProxy(ContextProxy):
                 mech_list_mic = in_token.mech_list_mic
                 token = in_token.response_token
 
+                # https://github.com/jborean93/smbprotocol/issues/137
+                # Some really old SPNEGO implementations have mechListMIC with the same value as responseToken. This is
+                # a bug but needs to be handled by blanking out the mechListMIC.
+                if token and mech_list_mic == token:
+                    mech_list_mic = None
+
                 # If we have received the supported_mech then we don't need to send our own.
                 if in_token.supported_mech:
                     self.__chosen_mech = GSSMech.from_oid(in_token.supported_mech)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -365,6 +365,7 @@ def test_negotiate_with_ntlm_and_duplicate_response_token(ntlm_cred):
 
     _message_test(c, s)
 
+
 # NTLM scenarios
 
 @pytest.mark.parametrize('lm_compat_level', [None, 0, 1, 2])

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -26,6 +26,8 @@ from spnego._context import (
     UnwrapResult,
 )
 
+from spnego._spnego import NegTokenResp, unpack_token
+
 from spnego.exceptions import (
     SpnegoError,
 )
@@ -327,6 +329,41 @@ def test_negotiate_with_raw_ntlm(ntlm_cred):
 
     _message_test(c, s)
 
+
+def test_negotiate_with_ntlm_and_duplicate_response_token(ntlm_cred):
+    c = spnego.client(ntlm_cred[0], ntlm_cred[1], hostname=socket.gethostname(),
+                      options=spnego.NegotiateOptions.use_negotiate)
+    s = spnego.server(options=spnego.NegotiateOptions.use_negotiate)
+
+    negotiate = c.step()
+    assert not c.complete
+    assert not s.complete
+
+    challenge = s.step(negotiate)
+
+    # Set the mechListMIC to the same value as responseToken in the challenge to replicate the bug this is testing
+    neg_token_resp = unpack_token(challenge)
+    assert isinstance(neg_token_resp, NegTokenResp)
+    neg_token_resp.mech_list_mic = neg_token_resp.response_token
+    challenge = neg_token_resp.pack()
+
+    assert not c.complete
+    assert not s.complete
+
+    authenticate = c.step(challenge)
+    assert not c.complete
+    assert not s.complete
+
+    mech_list = s.step(authenticate)
+    assert not c.complete
+    assert s.complete
+
+    final = c.step(mech_list)
+    assert final is None
+    assert c.complete
+    assert s.complete
+
+    _message_test(c, s)
 
 # NTLM scenarios
 


### PR DESCRIPTION
Older SPNEGO logic with NTLM (and possibly others) had the `mechListMIC` in the `NegTokenResp` set to the same value as the `responseToken`. While most modern servers no longer do this it's still possible to encounter something out there that still follows this behaviour causing the client to fail to the authentication because the `mechListMIC` was invalid

> SpnegoError (6): A token had an invalid Message Integrity Check (MIC), Context: Invalid Message integrity Check (MIC) detected

When checking MIT krb5 we can see that they ignore the duplicate value when it matches what is set for `responseToken` so this behaviour is just replicated here https://github.com/krb5/krb5/blob/3f5a348287646d65700854650fe668b9c4249013/src/lib/gssapi/spnego/spnego_mech.c#L3734-L3744.

Fixes https://github.com/jborean93/smbprotocol/issues/137 - where the issue was originally reported