### PR TITLE
Ntlm hash on windows

### DIFF
--- a/spnego/_ntlm_raw/crypto.py
+++ b/spnego/_ntlm_raw/crypto.py
@@ -65,7 +65,7 @@ class RC4Handle:
         self._handle = cipher.encryptor()
 
 
-def _is_ntlm_hash(password: str) -> bool:
+def is_ntlm_hash(password: str) -> bool:
     return bool(_NTLM_HASH_PATTERN.match(password))
 
 
@@ -332,7 +332,7 @@ def lmowfv1(password: str) -> bytes:
     .. _NTLM v1 Authentication:
         https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/464551a8-9fc4-428e-b3d3-bc5bfb2e73a5
     """
-    if _is_ntlm_hash(password):
+    if is_ntlm_hash(password):
         return base64.b16decode(password.split(':')[0].upper())
 
     # Fix the password to upper case and pad the length to exactly 14 bytes. While it is true LM only authentication
@@ -375,7 +375,7 @@ def ntowfv1(password: str) -> bytes:
     .. _NTLM v1 Authentication:
         https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/464551a8-9fc4-428e-b3d3-bc5bfb2e73a5
     """
-    if _is_ntlm_hash(password):
+    if is_ntlm_hash(password):
         return base64.b16decode(password.split(':')[1].upper())
 
     return md4(password.encode('utf-16-le'))

--- a/spnego/auth.py
+++ b/spnego/auth.py
@@ -8,6 +8,10 @@ from spnego._context import (
     ContextReq,
 )
 
+from spnego._ntlm_raw.crypto import (
+    is_ntlm_hash
+)
+
 from spnego.channel_bindings import (
     GssChannelBindings,
 )
@@ -70,6 +74,12 @@ def _new_context(
     # Negotiate auth is used in the CredSSP authentication process.
     if proto == 'credssp':
         proxy = CredSSPProxy
+
+    # If the procotol has been explicitly set to NTLM and an NTLM hash has been provided as the password, do not favour
+    # the platform implementations. Instead, use the Python NTLMProxy implementation, since SSPI/GSSAPI so not allow
+    # authentication using hashes.
+    elif proto == 'ntlm' and password is not None and is_ntlm_hash(password):
+        proxy = NTLMProxy
 
     elif options & NegotiateOptions.use_sspi or (not use_specified and proto in sspi_protocols):
         proxy = SSPIProxy


### PR DESCRIPTION
Use NTLMProxy if explicitly specified and password is NTLM hash

pyspnego prefers the platform implementations (e.g. SSPI) over the python implementations (e.g. NTLM). The SSPI implementation does not allow the user to specify a NT or LM hash for use with NTLM authentication, whereas the NTLMProxy does. In this specific case, we don't want pyspnego to prefer SSPIProxy, but instead use NTLMProxy.
