### PR TITLE
Support for different credential types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.4.0 - TBD
 
+### Features
+
 * Add `usage` argument for `tls.default_tls_context` to control whether the context is for a initiator or acceptor
 * Add type annotations and include `py.typed` in the package for downstream library use
 * Expose the `ContextProxy` class for type annotation use
@@ -10,6 +12,15 @@
   * `sslcontext`: The SSL context used to create the TLS object
   * `ssl_object`: The TLS object used during the CredSSP exchange
 * The `client_credential` property on `CredSSP` has been removed in favour of `context.get_extra_info('client_credential')
+* Added support for custom credential types
+  * Can be used to for things like NTLM authentication with NT/LM hashes, Kerberos with a keytab or from an explicit CCache, etc
+* Support calling SSPI through `pyspnego`'s Negotiate proxy context
+  * This allows users on Windows to still use Negotiate auth but with a complex set of credentials
+  * Also opens up the ability to use Negotiate but only with Kerberos auth
+
+### Deprecations
+
+* The `username` and `password` property on the auth context object are deprecated and will return `None` until it is removed in a future release
 
 
 ## 0.3.1 - 2021-10-29

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ disallow_untyped_defs = true
 disallow_incomplete_defs = true
 check_untyped_defs = true
 disallow_untyped_decorators = true
-no_implicit_reexport = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 

--- a/src/spnego/__init__.py
+++ b/src/spnego/__init__.py
@@ -15,14 +15,28 @@ from spnego._context import (
     WinRMWrapResult,
     WrapResult,
 )
+from spnego._credential import (
+    Credential,
+    CredentialCache,
+    KerberosCCache,
+    KerberosKeytab,
+    NTLMHash,
+    Password,
+)
 from spnego.auth import client, server
 from spnego.exceptions import NegotiateOptions
 
 __all__ = [
     "ContextProxy",
     "ContextReq",
+    "Credential",
+    "CredentialCache",
     "IOVUnwrapResult",
     "IOVWrapResult",
+    "KerberosCCache",
+    "KerberosKeytab",
+    "NTLMHash",
+    "Password",
     "NegotiateOptions",
     "UnwrapResult",
     "WinRMWrapResult",

--- a/src/spnego/_credential.py
+++ b/src/spnego/_credential.py
@@ -1,0 +1,306 @@
+# Copyright: (c) 2021, Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+"""Credentials that can be used by a client.
+
+These are the various credentials that can be used as a client to authenticate
+with a service. See the docstring for each credential type to identify what
+credentials are usable for each authenticaton protocol.
+"""
+
+import dataclasses
+import typing
+
+from spnego._ntlm_raw.crypto import is_ntlm_hash
+from spnego.exceptions import InvalidCredentialError, NoCredentialError
+
+# FUTURE: Add Anonymous credential class
+
+
+@dataclasses.dataclass
+class Password:
+    """Plaintext username and password credential.
+
+    This is the simple username and password credential that is supported by
+    all authentication protocols.
+
+    Attributes:
+        username: The username.
+        password: The password for the user.
+    """
+
+    username: str
+    password: str = dataclasses.field(repr=False)
+
+    @property
+    def supported_protocols(self) -> typing.List[str]:
+        """List of protocols the credential can be used for."""
+        return ["credssp", "kerberos", "ntlm"]
+
+
+@dataclasses.dataclass
+class CredentialCache:
+    """Cached credential.
+
+    Uses the provider specific cached credential. Can also specify a username
+    to select a specific cached credential.
+
+    Attributes:
+        username: Optional username used to select a specific credential in the
+            cache.
+    """
+
+    username: typing.Optional[str] = None
+
+    @property
+    def supported_protocols(self) -> typing.List[str]:
+        return ["kerberos", "ntlm"]
+
+
+@dataclasses.dataclass
+class NTLMHash:
+    """NTLM LM/NT Hash credential.
+
+    Used with :class:`NTLMProxy` for NTLM authentication backed by an NT and/or
+    LM hash value. In modern iterations of NTLM only the NT hash needs to be
+    specified and LM is ignored but both can be specified and the NTLM code
+    will use them as necessary.
+
+    Attributes:
+        username: The username the hashes are for.
+        lm_hash: The LM hash as a hex string, can be `None` in most cases.
+        nt_hash: The NT hash as a hex string.
+    """
+
+    username: str
+    lm_hash: typing.Optional[str] = dataclasses.field(default=None, repr=False)
+    nt_hash: typing.Optional[str] = dataclasses.field(default=None, repr=False)
+
+    @property
+    def supported_protocols(self) -> typing.List[str]:
+        """List of protocols the credential can be used for."""
+        return ["ntlm"]
+
+
+@dataclasses.dataclass
+class KerberosKeytab:
+    """Kerberos Keytab Credential.
+
+    Used with :class:`GSSAPIProxy` for Kerberos authentication. It is used to
+    retrieve a Kerberos ticket using a keytab for authentication rather than a
+    password. The keytab value is specified in the form ``TYPE:RESIDUAL`` where
+    the ``TYPE`` supported is down to the installed Kerberos/GSSAPI
+    implementation and ``RESIDUAL`` is a value specific to the type. Common
+    types are:
+
+        FILE: The value is the path to a keytab.
+        MEMORY: The value is a unique identifier to a keytab stored in memory
+            of the current process. It must be resolvable by the linked GSSAPI
+            provider that this library uses.
+
+    There are other ccache types but they are mostly platform or GSSAPI
+    implementation specific.
+
+    .. Note:
+        This only works on Linux, Windows does not have the concept of a
+        keytab.
+
+    .. Note:
+        The principal of the keytab entry to use must be specified. In the
+        future this may become option if the required APIs are implemented in
+        pykrb5.
+
+    Attributes:
+        keytab: The keytab to use for authentication. The path will not be
+            expanded of have variables substituted so should be the absolute
+            path to the keytab.
+        principal: The Kerberos principal to get the credential for. Should be
+            in the UPN form `username@REALM.COM`.
+    """
+
+    keytab: str
+    principal: str
+
+    @property
+    def supported_protocols(self) -> typing.List[str]:
+        """List of protocols the credential can be used for."""
+        return ["kerberos"]
+
+
+@dataclasses.dataclass
+class KerberosCCache:
+    """Kerberos CCache Credential.
+
+    Used with :class:`GSSAPIProxy` for Kerberos authentication. It is used to
+    specify the credential cache that has the stored Kerberos credential for
+    authentication. The ccache value is specified in the form ``TYPE:RESIDUAL``
+    where the ``TYPE`` supported is down to the installed Kerberos/GSSAPI
+    implementation and ``RESIDUAL`` is a value specific to the type. Common
+    types are:
+
+        DIR: The value is the path to a directory containing a collection of
+            `FILE` caches.
+        FILE: The value is the path to an individual cache.
+        MEMORY: The value is a unique identifier to a cache stored in memory of
+            the current process. It must be resolvable by the linked GSSAPI
+            provider that this library uses.
+
+    There are other ccache types but they are mostly platform or GSSAPI
+    implementation specific.
+
+    .. Note:
+        This only works on Linux, Windows does not have the concept of
+        separate CCaches.
+
+    Attributes:
+        ccache: The ccache in the form ``TYPE:RESIDUAL`` to use for a Kerberos
+            credential. The path will not be expanded of have variables
+            substituted so should be the absolute path to the ccache.
+        principal: Optional principal to get in the credential cache specified.
+    """
+
+    ccache: str
+    principal: typing.Optional[str] = None
+
+    @property
+    def supported_protocols(self) -> typing.List[str]:
+        """List of protocols the credential can be used for."""
+        return ["kerberos"]
+
+
+# FUTURE: Expose this as an official credential
+# @dataclasses.dataclass
+# class CredSSPSmartCard:
+#     """CredSSP Smart Card Credential.
+
+#     Used with :class:`CredSSPProxy` for CredSSP authentication. It is used to
+#     delegate a smart card credential to the peer rather than a
+#     username/password. It must be supplied with another NTLM/Kerberos supported
+#     credential as this is only used for the delegation part of the CredSSP
+#     authentication process.
+
+#     The values are modeled after `MS-CSSP TSSmartCardCreds`_.
+
+#     Attributes:
+#         pin: The user's smart card PIN.
+#         key_spec: The specification of the user's smart card.
+#         card_name: The name of the smart card.
+#         reader_name: The name of the smart card reader.
+#         container_name: Name of the certificate container.
+#         csp_name: Name of the CSP.
+#         user_hint: The user's account hint.
+#         domain_hint: The user's domain name hint.
+
+#     .. _MS-CSSP TSSmartCardCreds:
+#         https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cssp/4251d165-cf01-4513-a5d8-39ee4a98b7a4
+#     """
+#     pin: bytes
+#     key_spec: int
+#     card_name: typing.Optional[bytes] = None
+#     reader_name: typing.Optional[bytes] = None
+#     container_name: typing.Optional[bytes] = None
+#     csp_name: typing.Optional[bytes] = None
+#     user_hint: typing.Optional[bytes] = None
+#     domain_hint: typing.Optional[bytes] = None
+
+#     @property
+#     def supported_protocols(self) -> typing.List[str]:
+#         return ["credssp"]
+
+
+# @dataclasses.dataclass
+# class CredSSPRemoteGuardPackage:
+#     """CredSSP Remote Guard Credential.
+
+#     Used with :class:`CredSSPProxy` for CredSSP authentication. It is used to
+#     delegate credential protected by `Remote Credential Guard`_. It must be
+#     supplied with another NTLM/Kerberos supported credential as this is only
+#     used for the delegation part of the CredSSP authentication process.
+#     Multiple instance of this can be passed in with the first entry being the
+#     logon credential and the remaining instances being the supplemental
+#     credentials.
+
+#     The values are modeled after `MS-CSSP TSRemoteGuardPackageCred`_.
+
+#     .. _Remote Credential Guard:
+#         https://docs.microsoft.com/en-us/windows/security/identity-protection/remote-credential-guard
+
+#     .. _MS-CSSP TSRemoteGuardPackageCred:
+#         https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-cssp/173eee44-1a2c-463f-b909-c15db01e68d7
+#     """
+#     package_name: str
+#     cred_buffer: bytes
+
+#     @property
+#     def supported_protocols(self) -> typing.List[str]:
+#         return ["credssp"]
+
+
+Credential = typing.Union[CredentialCache, KerberosCCache, KerberosKeytab, NTLMHash, Password]
+
+
+def unify_credentials(
+    username: typing.Optional[typing.Union[str, Credential, typing.List[Credential]]] = None,
+    password: typing.Optional[str] = None,
+    required_protocol: typing.Optional[str] = None,
+) -> typing.List[Credential]:
+    """Process user input credentials.
+
+    Converts the user facing credential input into a list of credentials that
+    is known by spnego. Also filters out any duplicate credentials/ones that
+    are rendered obsolete by any ones preceding it. For example NTLMHash won't
+    be used if it's specified after Password in the credential list.
+
+    Args:
+        username: The username or list of credentials to process.
+        password: The password for username when it's a string.
+        required_protocol: Optionally checks that at least 1 credential must
+            support the protocol specified.
+
+    Returns:
+        typing.List[Credential]: A list of credentials based on the free-form
+        input.
+    """
+    if username:
+        if isinstance(username, str):
+            if not password:
+                username = [CredentialCache(username=username)]
+            elif is_ntlm_hash(password):
+                lm, nt = password.split(":", 1)
+                username = [NTLMHash(username=username, lm_hash=lm, nt_hash=nt)]
+            else:
+                username = [Password(username=username, password=password)]
+
+        elif not isinstance(username, list):
+            username = [username]
+
+    else:
+        username = [CredentialCache()]
+
+    credentials: typing.List[Credential] = []
+    used_protocols: typing.Set[str] = set()
+    for cred in username:
+        if not isinstance(cred, (CredentialCache, KerberosCCache, KerberosKeytab, NTLMHash, Password)):
+            raise InvalidCredentialError(
+                context_msg="Invalid username/credential specified, must be a string or Credential object."
+            )
+
+        # Remove any credential that only implements protocols that are already covered by one before it.
+        # FUTURE: This might be problematic with the CredSSP ones
+        cred_useful = False
+        for cred_protocol in cred.supported_protocols:
+            if cred_protocol not in used_protocols:
+                used_protocols.add(cred_protocol)
+                cred_useful = True
+
+        if cred_useful:
+            credentials.append(cred)
+
+    if required_protocol and required_protocol not in used_protocols:
+        found_protocols = ", ".join(sorted(used_protocols))
+        raise NoCredentialError(
+            context_msg=f"A credential for {required_protocol} is needed but only found "
+            f"credentials for {found_protocols}"
+        )
+
+    return credentials

--- a/src/spnego/_ntlm.py
+++ b/src/spnego/_ntlm.py
@@ -18,6 +18,13 @@ from spnego._context import (
     WrapResult,
     split_username,
 )
+from spnego._credential import (
+    Credential,
+    CredentialCache,
+    NTLMHash,
+    Password,
+    unify_credentials,
+)
 from spnego._ntlm_raw.crypto import (
     RC4Handle,
     compute_response_v1,
@@ -196,19 +203,26 @@ def _get_workstation() -> typing.Optional[str]:
 class _NTLMCredential:
     def __init__(
         self,
-        domain: typing.Optional[str] = None,
-        username: typing.Optional[str] = None,
-        password: typing.Optional[str] = None,
+        credential: typing.Optional[Credential] = None,
     ) -> None:
         self._store: typing.Optional[str]
-        if password:
-            self.domain = domain
-            self.username = username
-            self.lm_hash = lmowfv1(password)
-            self.nt_hash = ntowfv1(password)
+        if isinstance(credential, Password):
             self._store = "explicit"
+            self.domain, self.username = split_username(credential.username)
+            self.lm_hash = lmowfv1(credential.password)
+            self.nt_hash = ntowfv1(credential.password)
+
+        elif isinstance(credential, NTLMHash):
+            self._store = "explicit"
+            self.domain, self.username = split_username(credential.username)
+            self.lm_hash = base64.b16decode(credential.lm_hash.upper()) if credential.lm_hash else b"\x00" * 16
+            self.nt_hash = base64.b16decode(credential.nt_hash.upper()) if credential.nt_hash else b"\x00" * 16
 
         else:
+            domain = username = None
+            if isinstance(credential, CredentialCache):
+                domain, username = split_username(credential.username)
+
             self._store = _get_credential_file()
             self.domain, self.username, self.lm_hash, self.nt_hash = _get_credential(self._store, domain, username)
 
@@ -221,8 +235,8 @@ class NTLMProxy(ContextProxy):
 
     def __init__(
         self,
-        username: typing.Optional[str],
-        password: typing.Optional[str],
+        username: typing.Optional[typing.Union[str, Credential, typing.List[Credential]]] = None,
+        password: typing.Optional[str] = None,
         hostname: typing.Optional[str] = None,
         service: typing.Optional[str] = None,
         channel_bindings: typing.Optional[GssChannelBindings] = None,
@@ -230,11 +244,11 @@ class NTLMProxy(ContextProxy):
         usage: str = "initiate",
         protocol: str = "ntlm",
         options: NegotiateOptions = NegotiateOptions.none,
-        _is_wrapped: bool = False,
         **kwargs: typing.Any,
     ) -> None:
+        credentials = unify_credentials(username, password, required_protocol="ntlm")
         super(NTLMProxy, self).__init__(
-            username, password, hostname, service, channel_bindings, context_req, usage, protocol, options, _is_wrapped
+            credentials, hostname, service, channel_bindings, context_req, usage, protocol, options
         )
 
         self._complete = False
@@ -270,8 +284,7 @@ class NTLMProxy(ContextProxy):
             self._context_req &= ~NegotiateFlags.extended_session_security
 
         if self.usage == "initiate":
-            domain, user = split_username(self.username)
-            self._credential = _NTLMCredential(domain=domain, username=user, password=self.password)
+            self._credential = _NTLMCredential(next(c for c in credentials if "ntlm" in c.supported_protocols))
 
             self._lm = lm_compat_level < 2
             self._nt_v1 = lm_compat_level < 3
@@ -474,7 +487,10 @@ class NTLMProxy(ContextProxy):
         ):
             raise OperationNotAvailableError(context_msg="Anonymous user authentication not implemented")
 
-        self._credential = _NTLMCredential(domain=auth.domain_name, username=auth.user_name)
+        username = auth.user_name
+        if auth.domain_name:
+            username = f"{auth.domain_name}\\{username}"
+        self._credential = _NTLMCredential(CredentialCache(username=username))
         expected_mic = None
 
         if auth.nt_challenge_response and len(auth.nt_challenge_response) > 24:
@@ -581,11 +597,8 @@ class NTLMProxy(ContextProxy):
         return WinRMWrapResult(header=enc_data[:16], data=enc_data[16:], padding_length=0)
 
     def unwrap(self, data: bytes) -> UnwrapResult:
-        if not self._handle_in:
-            raise NoContextError(context_msg="NTLM context has not been completed")
-
         signature = data[:16]
-        msg = self._handle_in.update(data[16:])
+        msg = self._handle_in.update(data[16:])  # type: ignore[union-attr]
         self.verify(msg, signature)
 
         return UnwrapResult(data=msg, encrypted=True, qop=0)

--- a/tests/_ntlm_raw/test_messages.py
+++ b/tests/_ntlm_raw/test_messages.py
@@ -314,6 +314,25 @@ def test_negotiate_invalid_size():
         messages.Negotiate.unpack(b"NTLMSSP\x00\x01\x00\x00\x00")
 
 
+def test_negotiate_unpack_invalid_msg():
+    with pytest.raises(ValueError, match="Input message was not a NTLM Negotiate message"):
+        messages.Negotiate.unpack(
+            b"\x4E\x54\x4C\x4D\x53\x53\x50\x00"
+            b"\x02\x00\x00\x00"
+            b"\x0C\x00"
+            b"\x0C\x00"
+            b"\x38\x00\x00\x00"
+            b"\x33\x82\x02\xE2"
+            b"\x01\x23\x45\x67\x89\xAB\xCD\xEF"
+            b"\x00\x00\x00\x00\x00\x00\x00\x00"
+            b"\x00\x00"
+            b"\x00\x00"
+            b"\x00\x00\x00\x00"
+            b"\x06\x00\x70\x17\x00\x00\x00\x0F"
+            b"\x53\x00\x65\x00\x72\x00\x76\x00\x65\x00\x72\x00"
+        )
+
+
 def test_challenge_pack():
     challenge = messages.Challenge()
 
@@ -589,6 +608,21 @@ def test_challenge_unpack_encoding():
     assert actual.server_challenge == b"\x11" * 8
     assert actual.target_info is None
     assert actual.version is None
+
+
+def test_challenge_unpack_invalid_msg():
+    with pytest.raises(ValueError, match="Input message was not a NTLM Challenge message"):
+        messages.Challenge.unpack(
+            b"\x4E\x54\x4C\x4D\x53\x53\x50\x00"
+            b"\x01\x00\x00\x00"
+            b"\x00\x00\x00\x00"
+            b"\x00\x00"
+            b"\x00\x00"
+            b"\x20\x00\x00\x00"
+            b"\x00\x00"
+            b"\x00\x00"
+            b"\x20\x00\x00\x00"
+        )
 
 
 def test_authenticate_pack():
@@ -1089,6 +1123,21 @@ def test_authenticate_unpack_mic_no_version():
 def test_authenticate_invalid_size():
     with pytest.raises(ValueError, match="Invalid NTLM Authenticate raw byte length"):
         messages.Authenticate.unpack(b"NTLMSSP\x00\x03\x00\x00\x00")
+
+
+def test_authenticate_unpack_invalid_msg():
+    with pytest.raises(ValueError, match="Input message was not a NTLM Authenticate message"):
+        messages.Authenticate.unpack(
+            b"\x4E\x54\x4C\x4D\x53\x53\x50\x00"
+            b"\x01\x00\x00\x00"
+            b"\x00\x00\x00\x00"
+            b"\x00\x00"
+            b"\x00\x00"
+            b"\x20\x00\x00\x00"
+            b"\x00\x00"
+            b"\x00\x00"
+            b"\x20\x00\x00\x00"
+        )
 
 
 def test_filetime_pack():

--- a/tests/integration/main.yml
+++ b/tests/integration/main.yml
@@ -341,6 +341,30 @@
     - HTTP
     - cifs
 
+  - name: create user keytab - MIT
+    command: ktutil
+    args:
+      chdir: ~/
+      creates: ~/user.keytab
+      stdin: "addent -password -p {{ domain_upn }} -k 1 -e aes256-cts\n{{ domain_password }}\nwrite_kt user.keytab"
+    become: no
+    when: krb_provider == 'MIT'
+
+  - name: create user keytab - Heimdal
+    command: >-
+      ktutil
+      --keytab=user.keytab
+      add
+      --principal={{ domain_upn }}
+      --kvno=1
+      --enctype=aes256-cts
+      --password={{ domain_password }}
+    args:
+      chdir: ~/
+      creates: ~/user.keytab
+    become: no
+    when: krb_provider == 'Heimdal'
+
   - name: ensure wheel dir exists
     file:
       path: ~/wheels

--- a/tests/integration/templates/test_integration.py.tmpl
+++ b/tests/integration/templates/test_integration.py.tmpl
@@ -546,6 +546,91 @@ $username = '{0}'
     assert c_iov_res.buffers[1].data == plaintext
 
 
+@pytest.mark.skipif(os.name == 'nt', reason='Windows doesnt support keytabs')
+@pytest.mark.parametrize('protocol', ['kerberos', 'negotiate'])
+def test_kerberos_authentication_with_keytab(protocol, monkeypatch):
+    monkeypatch.setenv('KRB5_KTNAME', '/etc/HTTP.keytab')
+
+    auth_kwargs = {}
+    if protocol != 'negotiate':
+        auth_kwargs['protocol'] = protocol
+
+    keytab = spnego.KerberosKeytab(keytab=os.path.expanduser('~/user.keytab'), principal=USERNAME)
+    c = spnego.client(keytab, hostname=HOST_FQDN, service='HTTP', **auth_kwargs)
+    s = spnego.server(**auth_kwargs)
+
+    in_token = None
+    while not c.complete:
+        out_token = c.step(in_token)
+        if not out_token:
+            break
+
+        in_token = s.step(out_token)
+
+    assert s.client_principal == USERNAME
+    assert s.session_key == c.session_key
+    assert c.negotiated_protocol == 'kerberos'
+    assert s.negotiated_protocol == 'kerberos'
+
+
+@pytest.mark.parametrize('protocol, use_cache_cred', [
+    ('kerberos', False),
+    ('kerberos', True),
+    ('negotiate', False),
+    ('negotiate', True),
+])
+@pytest.mark.skipif(os.name == 'nt', reason='Due to how its run this doesnt really work for Windows')
+def test_kerberos_authentication_with_cache(protocol, use_cache_cred, monkeypatch, tmp_path):
+    cred = None
+
+    monkeypatch.setenv('KRB5_KTNAME', '/etc/HTTP.keytab')
+
+    kinit_args = ['kinit']
+    config = {}
+    if KERBEROS_PROVIDER == 'Heimdal':
+        kinit_args.append('--password-file=STDIN')
+
+    kinit_args.append(USERNAME)
+
+    tmp_ccache = tmp_path / 'test_ccache'
+    open(tmp_ccache, mode='wb').close()
+    kinit_env = os.environ.copy()
+    kinit_env['KRB5CCNAME'] = tmp_ccache
+
+    if use_cache_cred:
+        cred = spnego.KerberosCCache(ccache=tmp_ccache)
+
+    else:
+        monkeypatch.setenv('KRB5CCNAME', tmp_ccache)
+        kinit_env['KRB5CCNAME'] = tmp_ccache
+
+    process = subprocess.Popen(kinit_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                env=kinit_env)
+    stdout, stderr = process.communicate(PASSWORD.encode() + b'\n')
+    if process.returncode != 0:
+        raise Exception("Failed to get Kerberos credential %d: %s %s" % (process.returncode, stdout, stderr))
+
+    auth_kwargs = {}
+    if protocol != 'negotiate':
+        auth_kwargs['protocol'] = protocol
+
+    c = spnego.client(cred, hostname=HOST_FQDN, service='HTTP', **auth_kwargs)
+    s = spnego.server(**auth_kwargs)
+
+    in_token = None
+    while not c.complete:
+        out_token = c.step(in_token)
+        if not out_token:
+            break
+
+        in_token = s.step(out_token)
+
+    assert s.client_principal == USERNAME
+    assert s.session_key == c.session_key
+    assert c.negotiated_protocol == 'kerberos'
+    assert s.negotiated_protocol == 'kerberos'
+
+
 @pytest.mark.skipif(KERBEROS_PROVIDER != 'MIT', reason="Cannot test on Windows and Heimdal does not work")
 def test_winrm_rc4_wrapping(monkeypatch):
     context_kwargs = {

--- a/tests/test_negotiate.py
+++ b/tests/test_negotiate.py
@@ -5,7 +5,9 @@
 import pytest
 
 import spnego
+import spnego._gss
 from spnego._context import GSSMech
+from spnego._negotiate import NegotiateProxy
 from spnego._spnego import NegState, NegTokenInit, NegTokenResp
 from spnego.exceptions import BadMechanismError, InvalidTokenError
 
@@ -75,3 +77,13 @@ def test_token_acceptor_first(ntlm_cred):
     assert final_token is None
     assert c.complete
     assert s.complete
+
+
+@pytest.mark.skipif("ntlm" not in spnego._sspi.SSPIProxy.available_protocols(), reason="Requires SSPI library")
+def test_iov_available_sspi():
+    assert NegotiateProxy.iov_available()
+
+
+@pytest.mark.skipif(not spnego._gss.HAS_GSSAPI, reason="Requires the gssapi library to be installed for testing")
+def test_iov_available_gssapi():
+    assert NegotiateProxy.iov_available() == spnego._gss.GSSAPIProxy.iov_available()

--- a/tests/test_sspi.py
+++ b/tests/test_sspi.py
@@ -9,6 +9,7 @@ import pytest
 
 import spnego._sspi
 import spnego.iov
+from spnego.exceptions import InvalidCredentialError
 
 
 @pytest.mark.skipif("ntlm" not in spnego._sspi.SSPIProxy.available_protocols(), reason="Requires SSPI library")
@@ -83,3 +84,9 @@ def test_sspi_wrap_no_encryption(ntlm_cred):
     enc_data = c.wrap(plaintext, encrypt=False)
     dec_data = s.unwrap(enc_data.data)
     assert dec_data.data == plaintext
+
+
+@pytest.mark.skipif("ntlm" not in spnego._sspi.SSPIProxy.available_protocols(), reason="Requires SSPI library")
+def test_sspi_no_valid_cred():
+    with pytest.raises(InvalidCredentialError, match="No applicable credentials available"):
+        spnego._sspi.SSPIProxy(spnego.KerberosKeytab("user_princ", "ccache"), protocol="kerberos")


### PR DESCRIPTION
This PR adds support for supplying different credential types for authentication. This allows for some more advanced scenarios like using Kerberos from a keytab/ccache, NTLM with the explicit NT/LM hash. It also exposes an interface for anonymous credentials or the extra CredSSP delegation credentials for future work when needed.

Unfortunately the current UI is hardwired to username/password as 2 arguments so this will continue going forward with an ultimate goal to deprecate this at some point in the future (way in the future).