### PR TITLE
Treat invalid token inputs as InvalidTokenError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.1 - TBD
+
+* Ensure bad SPNEGO token inputs are raised as `InvalidTokenError` rather than `struct.error`
+
+
 ## 0.2.0 - 2021-09-22
 
 ### Breaking Changes

--- a/spnego/_negotiate.py
+++ b/spnego/_negotiate.py
@@ -3,6 +3,7 @@
 
 import base64
 import logging
+import struct
 import typing
 
 from spnego._context import (
@@ -145,7 +146,10 @@ class NegotiateProxy(ContextProxy):
         is_spnego = True
 
         if in_token:
-            in_token = unpack_token(in_token)
+            try:
+                in_token = unpack_token(in_token)
+            except struct.error as e:
+                raise InvalidTokenError(base_error=e, context_msg=f"Failed to unpack input token {e!s}")
 
             if isinstance(in_token, NegTokenInit):
                 mech_list_mic = in_token.mech_list_mic

--- a/tests/test_negotiate.py
+++ b/tests/test_negotiate.py
@@ -20,6 +20,14 @@ def test_token_rejected(ntlm_cred):
         c.step(token_resp)
 
 
+def test_token_invalid_input(ntlm_cred):
+    c = spnego.client(ntlm_cred[0], ntlm_cred[1], options=spnego.NegotiateOptions.use_negotiate)
+
+    c.step()
+    with pytest.raises(InvalidTokenError, match="Failed to unpack input token"):
+        c.step(b"\x00")
+
+
 def test_token_no_common_mechs(ntlm_cred):
     c = spnego.client(ntlm_cred[0], ntlm_cred[1], options=spnego.NegotiateOptions.use_negotiate)
 


### PR DESCRIPTION
Ensures any invalid inputs sent into the NegotiateProxy are raises as an
InvalidTokenError rather than the generic struct.error. This aligns the
behaviour of the pyspnego Negotiate provider with the platform specific
providers when attempting to parse an invalid input token..

Fixes https://github.com/jborean93/pyspnego/issues/24