### PR TITLE
Stop using deprecated TLS context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.0 - TBD
+
+* Add `usage` argument for `tls.default_tls_context` to control whether the context is for a initiator or acceptor
+
+
 ## 0.3.1 - 2021-10-29
 
 * Do not convert GSSAPI service to lowercase for GSSAPI and uppercase for SSPI

--- a/src/spnego/_credssp.py
+++ b/src/spnego/_credssp.py
@@ -57,7 +57,7 @@ def _create_tls_context(
     usage: str,
 ) -> CredSSPTLSContext:
     log.debug("Creating TLS context")
-    ctx = default_tls_context()
+    ctx = default_tls_context(usage=usage)
 
     if usage == "accept":
         # Cache the result for future operations

--- a/src/spnego/_version.py
+++ b/src/spnego/_version.py
@@ -1,4 +1,4 @@
 # Copyright: (c) 2020, Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
-__version__ = '0.3.1'
+__version__ = '0.4.0'

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -647,7 +647,7 @@ def test_gssapi_kerberos_auth_explicit_cred(acquire_cred_from, kerb_cred, monkey
 def test_credssp_ntlm_creds(options, restrict_tlsv12, version, ntlm_cred, monkeypatch, tmp_path):
     context_kwargs = {}
     if restrict_tlsv12:
-        credssp_context = spnego.tls.default_tls_context()
+        credssp_context = spnego.tls.default_tls_context(usage="accept")
 
         try:
             credssp_context.context.maximum_version = ssl.TLSVersion.TLSv1_2

--- a/tests/test_credssp.py
+++ b/tests/test_credssp.py
@@ -105,7 +105,7 @@ def test_credssp_invalid_handshake(ntlm_cred):
 
 
 def test_credssp_server_without_pub_key():
-    context = default_tls_context()
+    context = default_tls_context(usage="accept")
     with pytest.raises(OperationNotAvailableError, match="Provided tls context does not have a public key set"):
         credssp.CredSSPProxy("username", "password", usage="accept", credssp_tls_context=context)
 


### PR DESCRIPTION
The use of `ssl.PROTOCOL_TLS` is deprecated in favour of `ssl.PROTOCOL_TLS_CLIENT` and `ssl.PROTOCOL_TLS_SERVER`. While this is a slight breaking change as the client needs to pass in the usage the default is `initiate` which should cover the main scenarios when using this.