### PR TITLE
CredSSP min protocol and stage information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.0 - TBD
+
+* Added the `auth_stage` extra_info for a CredSSP context to give a human friendly indication of what sub auth stage it is up to.
+* Added the `protocol_version` extra_info for a CredSSP context to return the negotiated CredSSP protocol version.
+* Added the `credssp_min_protocol` keyword argument for a CredSSP context to set a minimum version the caller will accept of the peer.
+  * This can be set to `5+` to ensure the peer supports and applies the mitigations for CVE-2018-0886.
+
+
 ## 0.4.0 - 2022-02-16
 
 ### Features

--- a/src/spnego/_context.py
+++ b/src/spnego/_context.py
@@ -672,6 +672,18 @@ class ContextProxy(metaclass=abc.ABCMeta):
                 The :class:`ssl.SSLObject` instance used for the CredSSP
                 context.
 
+            auth_stage - added in 0.5.0:
+                A string representing that sub authentication stage being
+                performed in the CredSSP authentication stepping. The value
+                here is meant to be a human friendly representation and not
+                something to be relied upon.
+
+            protocol_version - added in 0.5.0:
+                The CredSSP protocol version that was negotiated between the
+                initiator and acceptor. This is the minimum version number
+                offered by both parties once the Negotiate authentication stage
+                is complete.
+
         Args:
             name: The name/id of the information to retrieve.
             default: The default value to return if the information is not

--- a/src/spnego/_version.py
+++ b/src/spnego/_version.py
@@ -1,4 +1,4 @@
 # Copyright: (c) 2020, Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"


### PR DESCRIPTION
Added the ability to specify the minimum CredSSP protocol version that
the caller allows. Talking to a peer that does not meet this minimum
requirement will result in an InvalidTokenError. This allows the caller
to only allow peers that have mitigated CVE-2018-0886 or any future CVEs
that result in a new protocol version.

Also adds the auth_stage and protocol_version extra info for a CredSSP
context proxy allowing the caller to inspect the protocol version that
was ultimately negotiated between the initiator and acceptor as well as
provide more details on the authentication process in CredSSP for more
context around error messages.