### PR TITLE
Fix retrieving negotiate attributes at the start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added the `protocol_version` extra_info for a CredSSP context to return the negotiated CredSSP protocol version.
 * Added the `credssp_min_protocol` keyword argument for a CredSSP context to set a minimum version the caller will accept of the peer.
   * This can be set to `5+` to ensure the peer supports and applies the mitigations for CVE-2018-0886.
+* Added safeguards when trying to retrieve the completed context attributes of `NegotiateProxy` before any contexts have been set up (https://github.com/jborean93/pyspnego/issues/33)
 
 
 ## 0.4.0 - 2022-02-16

--- a/src/spnego/_negotiate.py
+++ b/src/spnego/_negotiate.py
@@ -99,7 +99,7 @@ class NegotiateProxy(ContextProxy):
 
     @property
     def client_principal(self) -> typing.Optional[str]:
-        return self._context.client_principal
+        return self._context.client_principal if self._context_list else None
 
     @property
     def complete(self) -> bool:
@@ -107,15 +107,15 @@ class NegotiateProxy(ContextProxy):
 
     @property
     def context_attr(self) -> ContextReq:
-        return self._context.context_attr
+        return self._context.context_attr if self._context_list else ContextReq.none
 
     @property
     def negotiated_protocol(self) -> typing.Optional[str]:
-        return self._context.negotiated_protocol
+        return self._context.negotiated_protocol if self._context_list else None
 
     @property
     def session_key(self) -> bytes:
-        return self._context.session_key
+        return self._context.session_key if self._context_list else b""
 
     def step(self, in_token: typing.Optional[bytes] = None) -> typing.Optional[bytes]:
         log.debug("SPNEGO step input: %s", base64.b64encode(in_token or b"").decode())


### PR DESCRIPTION
Ensure an empty context list will not cause an exception when attempting
to retrieve attributes like client_principal, negotiate_protocol and so
on. This can occur when the client proxy has been created but before any
stepping has been done.

Fixes https://github.com/jborean93/pyspnego/issues/33