### PR TITLE
Ensure gss-ntlmssp adds NTLM MIC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.1 - TBD
+
+* Call `gss_inquire_sec_context_by_oid(ctx, spnego_req_mechlistMIC_oid)` when using pure NTLM over GSSAPI to ensure the token contains a MIC
+
+
 ## 0.5.0 - 2022-02-21
 
 * Added the `auth_stage` extra_info for a CredSSP context to give a human friendly indication of what sub auth stage it is up to.

--- a/src/spnego/_gss.py
+++ b/src/spnego/_gss.py
@@ -552,6 +552,13 @@ class GSSAPIProxy(ContextProxy):
         self._context_attr = int(self._context.actual_flags)
 
         if not self._is_wrapped:
+            # When using NTLM through GSSAPI without it being wrapped by SPNEGO
+            # this function needs to be called in order for gss-ntlmssp to add
+            # the MIC. We don't care about the value just that it would be added
+            # if it could.
+            # https://github.com/gssapi/gss-ntlmssp/issues/69
+            if self.protocol == "ntlm" and not self.complete:
+                _ = self._requires_mech_list_mic
             log.debug("GSSAPI step output: %s", base64.b64encode(out_token or b"").decode())
 
         return out_token

--- a/src/spnego/_version.py
+++ b/src/spnego/_version.py
@@ -1,4 +1,4 @@
 # Copyright: (c) 2020, Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"


### PR DESCRIPTION
Makes sure that when calling gss-ntlmssp over GSSAPI that it will add
the MIC to the last authentication message even when not being wrapped
through SPNEGO. This is done by query a specific context attribute of
the NTLM security context that notifies gss-ntlmssp that a MIC can be
added.