### PR TITLE
Fix Heap Allocation Errors on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.3 - TBD
+
+* Fix heap allocation errors when running with heap allocation monitoring on Windows
+
+
 ## 0.5.2 - 2022-04-29
 
 * Added custom MD4 hashing code for NTLM to use.

--- a/src/spnego/_sspi_raw/sspi.pxd
+++ b/src/spnego/_sspi_raw/sspi.pxd
@@ -29,18 +29,12 @@ cdef class SecurityContext:
 
 cdef class SecBufferDesc:
     cdef NativeSecBufferDesc _c_value
-    cdef list _buffers
 
     cdef PSecBufferDesc __c_value__(SecBufferDesc self)
 
 
 cdef class SecBuffer:
     cdef PSecBuffer c_value
-    cdef object sys_alloc
-    cdef object _is_owner
-    cdef void *_p_buffer
-
-    cdef replace_ptr(SecBuffer self, PSecBuffer ptr)
 
 
 cdef class _AuthIdentityBase:

--- a/src/spnego/_sspi_raw/sspi.pyi
+++ b/src/spnego/_sspi_raw/sspi.pyi
@@ -192,7 +192,7 @@ class SecurityContext:
 class SecBufferDesc:
     def __new__(
         cls,
-        buffers: t.List[SecBuffer],
+        buffer_count: int,
         version: int = 0,
     ) -> "SecBufferDesc": ...
     def __len__(self) -> int: ...
@@ -200,11 +200,6 @@ class SecBufferDesc:
         self,
         key: int,
     ) -> SecBuffer: ...
-    def __setitem__(
-        self,
-        key: int,
-        value: SecBuffer,
-    ) -> None: ...
     def __iter__(self) -> t.Iterator[SecBuffer]: ...
     @property
     def version(self) -> int: ...
@@ -215,12 +210,6 @@ class SecBufferDesc:
     ) -> None: ...
 
 class SecBuffer:
-    def __new__(
-        cls,
-        buffer_type: int,
-        buffer: t.Optional[bytes] = None,
-        length: int = 0,
-    ) -> "SecBuffer": ...
     def __len__(self) -> int: ...
     @property
     def buffer_type(self) -> int: ...
@@ -234,8 +223,9 @@ class SecBuffer:
     @buffer.setter
     def buffer(
         self,
-        value: bytes,
+        value: t.Optional[bytearray],
     ) -> None: ...
+    def free(self) -> None: ...
 
 class _AuthIdentityBase: ...
 

--- a/src/spnego/_version.py
+++ b/src/spnego/_version.py
@@ -1,4 +1,4 @@
 # Copyright: (c) 2020, Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"

--- a/tests/_sspi_raw/test_sspi.py
+++ b/tests/_sspi_raw/test_sspi.py
@@ -18,7 +18,13 @@ except ImportError:
 
 @pytest.mark.skipif(SKIP, reason="Can only test Cython code on Windows with compiled code.")
 def test_sec_buffer_desc_repr():
-    sec_buffer_desc = sspi.SecBufferDesc([sspi.SecBuffer(1, b"\x00\x01"), sspi.SecBuffer(2, b"\x02\x03")])
+    data1 = bytearray(b"\x01\x02")
+    data2 = bytearray(b"\x03\x04")
+    sec_buffer_desc = sspi.SecBufferDesc(2)
+    sec_buffer_desc[0].buffer_type = 1
+    sec_buffer_desc[0].buffer = data1
+    sec_buffer_desc[1].buffer_type = 2
+    sec_buffer_desc[1].buffer = data2
     actual = repr(sec_buffer_desc)
 
     assert actual == r"<spnego._sspi_raw.sspi.SecBufferDesc(ulVersion=0, cBuffers=2)>"
@@ -26,7 +32,13 @@ def test_sec_buffer_desc_repr():
 
 @pytest.mark.skipif(SKIP, reason="Can only test Cython code on Windows with compiled code.")
 def test_sec_buffer_desc_str():
-    sec_buffer_desc = sspi.SecBufferDesc([sspi.SecBuffer(1, b"\x00\x01"), sspi.SecBuffer(2, b"\x02\x03")])
+    data1 = bytearray(b"\x01\x02")
+    data2 = bytearray(b"\x03\x04")
+    sec_buffer_desc = sspi.SecBufferDesc(2)
+    sec_buffer_desc[0].buffer_type = 1
+    sec_buffer_desc[0].buffer = data1
+    sec_buffer_desc[1].buffer_type = 2
+    sec_buffer_desc[1].buffer = data2
     actual = str(sec_buffer_desc)
 
     assert actual == r"SecBufferDesc(ulVersion=0, cBuffers=2)"
@@ -34,52 +46,57 @@ def test_sec_buffer_desc_str():
 
 @pytest.mark.skipif(SKIP, reason="Can only test Cython code on Windows with compiled code.")
 def test_sec_buffer_desc_version():
-    sec_buffer_desc = sspi.SecBufferDesc([sspi.SecBuffer(1, b"\x00\x01"), sspi.SecBuffer(2, b"\x02\x03")])
+    data1 = bytearray(b"\x01\x02")
+    data2 = bytearray(b"\x03\x04")
+    sec_buffer_desc = sspi.SecBufferDesc(2)
+    sec_buffer_desc[0].buffer_type = 1
+    sec_buffer_desc[0].buffer = data1
+    sec_buffer_desc[1].buffer_type = 2
+    sec_buffer_desc[1].buffer = data2
     assert sec_buffer_desc.version == 0
     sec_buffer_desc.version = 1
     assert sec_buffer_desc.version == 1
 
 
 @pytest.mark.skipif(SKIP, reason="Can only test Cython code on Windows with compiled code.")
-def test_sec_buffer_invalid_init():
-    with pytest.raises(ValueError, match="Only an empty buffer can be created with length"):
-        sspi.SecBuffer(1, buffer=b"abc", length=10)
-
-
-@pytest.mark.skipif(SKIP, reason="Can only test Cython code on Windows with compiled code.")
 @pytest.mark.parametrize(
     "buffer, expected",
     [
-        (b"abc", 3),
-        (b"\x01\x02\x03\x04\x05", 5),
+        (bytearray(b"abc"), 3),
+        (bytearray(b"\x01\x02\x03\x04\x05"), 5),
     ],
 )
 def test_sec_buffer_length(buffer, expected):
-    assert len(sspi.SecBuffer(1, buffer=buffer)) == expected
+    sec_buffer_desc = sspi.SecBufferDesc(1)
+    sec_buffer = sec_buffer_desc[0]
+    sec_buffer.buffer_type = 1
+    sec_buffer.buffer = buffer
+
+    assert len(sec_buffer) == expected
 
 
 @pytest.mark.skipif(SKIP, reason="Can only test Cython code on Windows with compiled code.")
 def test_sec_buffer_repr():
-    sec_buffer = sspi.SecBuffer(1, b"\x01\x02\x03\x04")
+    data = bytearray(b"\x01\x02\x03\x04")
+    sec_buffer_desc = sspi.SecBufferDesc(1)
+    sec_buffer = sec_buffer_desc[0]
+    sec_buffer.buffer_type = 1
+    sec_buffer.buffer = data
     actual = repr(sec_buffer)
 
-    if sys.version_info[0] == 2:
-        assert actual == r"<spnego._sspi_raw.sspi.SecBuffer(cbBuffer=4, BufferType=1, pvBuffer='\x01\x02\x03\x04')>"
-
-    else:
-        assert actual == r"<spnego._sspi_raw.sspi.SecBuffer(cbBuffer=4, BufferType=1, pvBuffer=b'\x01\x02\x03\x04')>"
+    assert actual == r"<spnego._sspi_raw.sspi.SecBuffer(cbBuffer=4, BufferType=1, pvBuffer=b'\x01\x02\x03\x04')>"
 
 
 @pytest.mark.skipif(SKIP, reason="Can only test Cython code on Windows with compiled code.")
 def test_sec_buffer_str():
-    sec_buffer = sspi.SecBuffer(1, b"\x01\x02\x03\x04")
+    data = bytearray(b"\x01\x02\x03\x04")
+    sec_buffer_desc = sspi.SecBufferDesc(1)
+    sec_buffer = sec_buffer_desc[0]
+    sec_buffer.buffer_type = 1
+    sec_buffer.buffer = data
     actual = str(sec_buffer)
 
-    if sys.version_info[0] == 2:
-        assert actual == r"SecBuffer(cbBuffer=4, BufferType=1, pvBuffer='\x01\x02\x03\x04')"
-
-    else:
-        assert actual == r"SecBuffer(cbBuffer=4, BufferType=1, pvBuffer=b'\x01\x02\x03\x04')"
+    assert actual == r"SecBuffer(cbBuffer=4, BufferType=1, pvBuffer=b'\x01\x02\x03\x04')"
 
 
 @pytest.mark.skipif(SKIP, reason="Can only test Cython code on Windows with compiled code.")
@@ -138,7 +155,7 @@ def test_win_nt_auth_identity_set_password():
 @pytest.mark.skipif(SKIP, reason="Can only test Cython code on Windows with compiled code.")
 def test_accept_security_context_fail():
     with pytest.raises(WinError, match="The handle specified is invalid"):
-        sspi.accept_security_context(sspi.Credential(), sspi.SecurityContext(), sspi.SecBufferDesc([]))
+        sspi.accept_security_context(sspi.Credential(), sspi.SecurityContext(), sspi.SecBufferDesc(0))
 
 
 @pytest.mark.skipif(SKIP, reason="Can only test Cython code on Windows with compiled code.")
@@ -150,13 +167,13 @@ def test_acquire_credentials_handle_fail():
 @pytest.mark.skipif(SKIP, reason="Can only test Cython code on Windows with compiled code.")
 def test_decrypt_message_fail():
     with pytest.raises(WinError, match="The handle specified is invalid"):
-        sspi.decrypt_message(sspi.SecurityContext(), sspi.SecBufferDesc([]))
+        sspi.decrypt_message(sspi.SecurityContext(), sspi.SecBufferDesc(0))
 
 
 @pytest.mark.skipif(SKIP, reason="Can only test Cython code on Windows with compiled code.")
 def test_encrypt_message_fail():
     with pytest.raises(WinError, match="The handle specified is invalid"):
-        sspi.encrypt_message(sspi.SecurityContext(), sspi.SecBufferDesc([]))
+        sspi.encrypt_message(sspi.SecurityContext(), sspi.SecBufferDesc(0))
 
 
 @pytest.mark.skipif(SKIP, reason="Can only test Cython code on Windows with compiled code.")
@@ -168,7 +185,7 @@ def test_initialize_security_context_fail():
 @pytest.mark.skipif(SKIP, reason="Can only test Cython code on Windows with compiled code.")
 def test_make_signature_fail():
     with pytest.raises(WinError, match="The handle specified is invalid"):
-        sspi.make_signature(sspi.SecurityContext(), 0, sspi.SecBufferDesc([]))
+        sspi.make_signature(sspi.SecurityContext(), 0, sspi.SecBufferDesc(0))
 
 
 @pytest.mark.skipif(SKIP, reason="Can only test Cython code on Windows with compiled code.")
@@ -194,4 +211,4 @@ def test_query_context_attributes_invalid_handle(attribute):
 @pytest.mark.skipif(SKIP, reason="Can only test Cython code on Windows with compiled code.")
 def test_verify_signature_fail():
     with pytest.raises(WinError, match="The handle specified is invalid"):
-        sspi.verify_signature(sspi.SecurityContext(), sspi.SecBufferDesc([]))
+        sspi.verify_signature(sspi.SecurityContext(), sspi.SecBufferDesc(0))

--- a/tests/test_sspi.py
+++ b/tests/test_sspi.py
@@ -31,21 +31,18 @@ def test_build_iov_list(ntlm_cred):
     )
 
     assert len(actual) == 6
-    assert actual[0].buffer_type == spnego.iov.BufferType.header
-    assert actual[0].buffer == b"\x01"
-    assert actual[1].buffer_type == spnego.iov.BufferType.data
-    assert actual[1].buffer is not None
-    assert len(actual[1].buffer) == 5
-    assert actual[2].buffer_type == spnego.iov.BufferType.padding
-    assert actual[2].buffer is not None
-    assert len(actual[2].buffer) == 2
-    assert actual[3].buffer_type == spnego.iov.BufferType.header
-    assert actual[3].buffer is not None
-    assert len(actual[3].buffer) == 10
-    assert actual[4].buffer_type == spnego.iov.BufferType.stream
-    assert actual[4].buffer is None
-    assert actual[5].buffer_type == spnego.iov.BufferType.data
-    assert actual[5].buffer == b"\x02"
+    assert actual[0][0] == spnego.iov.BufferType.header
+    assert actual[0][1] == bytearray(b"\x01")
+    assert actual[1][0] == spnego.iov.BufferType.data
+    assert actual[1][1] == bytearray(5)
+    assert actual[2][0] == spnego.iov.BufferType.padding
+    assert actual[2][1] == bytearray(2)
+    assert actual[3][0] == spnego.iov.BufferType.header
+    assert actual[3][1] == bytearray(10)
+    assert actual[4][0] == spnego.iov.BufferType.stream
+    assert actual[4][1] == bytearray(0)
+    assert actual[5][0] == spnego.iov.BufferType.data
+    assert actual[5][1] == bytearray(b"\x02")
 
 
 @pytest.mark.skipif("ntlm" not in spnego._sspi.SSPIProxy.available_protocols(), reason="Requires SSPI library")


### PR DESCRIPTION
Fix errors when running with heap allocation checks on Windows. This
moves all the management of the SecBuffer objects to the Python code to
keep the Cython management simple. It also exposed some of the
inefficiencies that are in place where memory was copied to avoid it
mutating which can be addressed in a separate PR.

Fixes: https://github.com/jborean93/pyspnego/issues/40