### PR TITLE
Fix enum str representation for python 3.11 changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,8 @@ jobs:
           gssapi-provider: mit
         - os: macOS-12
           gssapi-provider: sspi
+        - os: macOS-12  # FIXME: Remove once gssapi and krb5 is fixed for this version
+          python-version: '3.11-dev'
 
         - os: windows-latest
           gssapi-provider: mit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,9 @@ jobs:
         - version: cp310-win_amd64
         - version: cp310-win32
         - version: cp311-win_amd64
+          prerelease: true
         - version: cp311-win32
+          prerelease: true
 
     steps:
     - uses: actions/download-artifact@v2
@@ -83,12 +85,12 @@ jobs:
         rm pyspnego-*.tar.gz
 
     - name: build wheel
-      uses: pypa/cibuildwheel@v2.1.1
+      uses: pypa/cibuildwheel@v2.8.1
       env:
         CIBW_ARCHS: all
         CIBW_BUILD: ${{ matrix.version }}
         CIBW_BUILD_VERBOSITY: 1
-        CIBW_PRERELEASE_PYTHONS: ${{ fromJSON('["true", "false"]')[matrix.version.startswith("cp311")] }}
+        CIBW_PRERELEASE_PYTHONS: ${{ matrix.prerelease || 'false' }}
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
         - version: cp39-win32
         - version: cp310-win_amd64
         - version: cp310-win32
+        - version: cp311-win_amd64
+        - version: cp311-win32
 
     steps:
     - uses: actions/download-artifact@v2
@@ -86,6 +88,7 @@ jobs:
         CIBW_ARCHS: all
         CIBW_BUILD: ${{ matrix.version }}
         CIBW_BUILD_VERBOSITY: 1
+        CIBW_PRERELEASE_PYTHONS: ${{ fromJSON('["true", "false"]')[matrix.version.startswith("cp311")] }}
 
     - uses: actions/upload-artifact@v2
       with:
@@ -112,6 +115,7 @@ jobs:
         - 3.8
         - 3.9
         - '3.10'
+        - '3.11-dev'
         python-arch:
         - x86
         - x64
@@ -203,6 +207,12 @@ jobs:
       with:
         name: artifact
         path: ./dist
+
+    - name: Remove test 3.11 wheels
+      shell: bash
+      run: |
+        rm -rf ./dist/*-cp311-*.whl
+        ls -al ./dist
 
     - name: Publish
       if: startsWith(github.ref, 'refs/tags/v')

--- a/src/spnego/_asn1.py
+++ b/src/spnego/_asn1.py
@@ -135,16 +135,22 @@ def extract_asn1_tlv(
             label_name = TypeTagNumber.native_labels().get(tag_number, "Unknown tag type")
             msg = "Invalid ASN.1 %s tags, actual tag class %s and tag number %s" % (
                 label_name,
-                tlv.tag_class,
-                tlv.tag_number,
+                f"{type(tlv.tag_class).__name__}.{tlv.tag_class.name}",
+                f"{type(tlv.tag_number).__name__}.{tlv.tag_number.name}"
+                if isinstance(tlv.tag_number, TypeTagNumber)
+                else tlv.tag_number,
             )
 
         else:
             msg = "Invalid ASN.1 tags, actual tag %s and number %s, expecting class %s and number %s" % (
-                tlv.tag_class,
-                tlv.tag_number,
-                tag_class,
-                tag_number,
+                f"{type(tlv.tag_class).__name__}.{tlv.tag_class.name}",
+                f"{type(tlv.tag_number).__name__}.{tlv.tag_number.name}"
+                if isinstance(tlv.tag_number, TypeTagNumber)
+                else tlv.tag_number,
+                f"{type(tag_class).__name__}.{tag_class.name}",
+                f"{type(tag_number).__name__}.{tag_number.name}"
+                if isinstance(tag_number, TypeTagNumber)
+                else tag_number,
             )
 
         if tlv.tag_class != tag_class or tlv.tag_number != tag_number:

--- a/src/spnego/_sspi.py
+++ b/src/spnego/_sspi.py
@@ -398,7 +398,9 @@ class SSPIProxy(ContextProxy):
 
             if alloc:
                 if buffer.type not in auto_alloc_size:
-                    raise ValueError("Cannot auto allocate buffer of type %s" % buffer.type)
+                    raise ValueError(
+                        "Cannot auto allocate buffer of type %s.%s" % (type(buffer).__name__, buffer.type.name)
+                    )
 
                 data = bytearray(auto_alloc_size[buffer.type])
 

--- a/src/spnego/_sspi.py
+++ b/src/spnego/_sspi.py
@@ -399,7 +399,7 @@ class SSPIProxy(ContextProxy):
             if alloc:
                 if buffer.type not in auto_alloc_size:
                     raise ValueError(
-                        "Cannot auto allocate buffer of type %s.%s" % (type(buffer).__name__, buffer.type.name)
+                        "Cannot auto allocate buffer of type %s.%s" % (type(buffer.type).__name__, buffer.type.name)
                     )
 
                 data = bytearray(auto_alloc_size[buffer.type])

--- a/src/spnego/channel_bindings.py
+++ b/src/spnego/channel_bindings.py
@@ -97,11 +97,13 @@ class GssChannelBindings:
         )
 
     def __str__(self) -> str:
-        return "{0} initiator_addr({1}|{2!r}) | acceptor_addr({3}|{4!r}) | application_data({5!r})".format(
+        return "{0} initiator_addr({1}.{2}|{3!r}) | acceptor_addr({4}.{5}|{6!r}) | application_data({7!r})".format(
             type(self).__name__,
-            str(self.initiator_addrtype),
+            type(self.initiator_addrtype).__name__,
+            self.initiator_addrtype.name,
             self.initiator_address,
-            str(self.acceptor_addrtype),
+            type(self.acceptor_addrtype).__name__,
+            self.acceptor_addrtype.name,
             self.acceptor_address,
             self.application_data,
         )

--- a/tests/test_channel_bindings.py
+++ b/tests/test_channel_bindings.py
@@ -43,40 +43,23 @@ def test_channel_bindings_unpack():
 def test_channel_bindings_str():
     actual = str(TEST_DATA)
 
-    if sys.version_info[0] == 2:
-        assert (
-            actual == r"GssChannelBindings initiator_addr(AddressType.inet|'\x01\x02\x03\x04') | "
-            r"acceptor_addr(AddressType.unspecified|'\x05\x06\x07\x08') | "
-            r"application_data('caf\xc3\xa9')"
-        )
-
-    else:
-        assert (
-            actual == r"GssChannelBindings initiator_addr(AddressType.inet|b'\x01\x02\x03\x04') | "
-            r"acceptor_addr(AddressType.unspecified|b'\x05\x06\x07\x08') | "
-            r"application_data(b'caf\xc3\xa9')"
-        )
+    assert (
+        actual == r"GssChannelBindings initiator_addr(AddressType.inet|b'\x01\x02\x03\x04') | "
+        r"acceptor_addr(AddressType.unspecified|b'\x05\x06\x07\x08') | "
+        r"application_data(b'caf\xc3\xa9')"
+    )
 
 
 def test_channel_bindings_repr():
     actual = repr(TEST_DATA)
 
-    if sys.version_info[0] == 2:
-        assert (
-            actual == r"spnego.channel_bindings.GssChannelBindings initiator_addrtype=<AddressType.inet: 2>|"
-            r"initiator_address='\x01\x02\x03\x04'|"
-            r"acceptor_addrtype=<AddressType.unspecified: 0>|"
-            r"acceptor_address='\x05\x06\x07\x08'|"
-            r"application_data='caf\xc3\xa9'"
-        )
-    else:
-        assert (
-            actual == r"spnego.channel_bindings.GssChannelBindings initiator_addrtype=<AddressType.inet: 2>|"
-            r"initiator_address=b'\x01\x02\x03\x04'|"
-            r"acceptor_addrtype=<AddressType.unspecified: 0>|"
-            r"acceptor_address=b'\x05\x06\x07\x08'|"
-            r"application_data=b'caf\xc3\xa9'"
-        )
+    assert (
+        actual == r"spnego.channel_bindings.GssChannelBindings initiator_addrtype=<AddressType.inet: 2>|"
+        r"initiator_address=b'\x01\x02\x03\x04'|"
+        r"acceptor_addrtype=<AddressType.unspecified: 0>|"
+        r"acceptor_address=b'\x05\x06\x07\x08'|"
+        r"application_data=b'caf\xc3\xa9'"
+    )
 
 
 def test_channel_bindings_eq():


### PR DESCRIPTION
Python 3.11 changed the way enums are represented with `str()`. This makes sure our use of this stays the same across versions by manually using the original form for things that are publicly exposed.

Fixes https://github.com/jborean93/pyspnego/issues/42