### PR TITLE
Migrate setup.py config to pyproject.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ on:
   - cron: 0 9 * * *
 
 jobs:
-  build:
+  build_sdist:
     name: build sdist and universal wheel
     runs-on: ubuntu-latest
     steps:
@@ -32,13 +32,10 @@ jobs:
 
     - uses: actions/setup-python@v2
 
-    - name: install build pre-requisites
-      run: pip install Cython setuptools wheel
-
     - name: build sdist and universal wheel
       run: |
-        SPNEGO_FORCE_CYTHONIZE=true python setup.py sdist
-        python setup.py bdist_wheel --universal
+        python -m pip install build
+        python -m build
 
     - uses: actions/upload-artifact@v2
       with:
@@ -48,15 +45,13 @@ jobs:
   build_wheels:
     name: build wheels
     needs:
-    - build
+    - build_sdist
 
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:
         include:
-        - version: cp36-win_amd64
-        - version: cp36-win32
         - version: cp37-win_amd64
         - version: cp37-win32
         - version: cp38-win_amd64
@@ -100,7 +95,7 @@ jobs:
   test:
     name: test
     needs:
-    - build
+    - build_sdist
     - build_wheels
 
     runs-on: ${{ matrix.os }}
@@ -112,7 +107,6 @@ jobs:
         - macOS-12
         - windows-latest
         python-version:
-        - 3.6
         - 3.7
         - 3.8
         - 3.9
@@ -216,7 +210,6 @@ jobs:
       shell: bash
       run: |
         rm -rf ./dist/*-cp311-*.whl
-        ls -al ./dist
 
     - name: Publish
       if: startsWith(github.ref, 'refs/tags/v')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.6.0 - TBD
+
+* Drop support for Python 3.6 - new minimum is 3.7+
+* Moved setuptools config into `pyproject.toml` and made `Cython` a build requirement for Windows
+  * For most users this is a hidden change
+  * If a tool follows the PEP 517 standard, like pip, this build dependency will work automatically
+  * The pre cythonised files are no longer included in the sdist going forward
+
+
 ## 0.5.4 - 2022-08-11
 
 * Fix str of enum values when running in Python 3.11 to be consistent with older versions

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,11 @@
-include __dont_use_cython__.txt
 include LICENSE
 include CHANGELOG.md
 include requirements-test.txt
 exclude .coverage
 exclude .gitignore
 exclude .pre-commit-config.yaml
-recursive-include src/spnego *.pyx *.pxd *.c
+recursive-include build_helpers *
+recursive-include src/spnego *.pyx *.pxd
+recursive-exclude src/spnego *.c
 recursive-include tests *
 recursive-exclude tests *.pyc

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ be used to decode raw NTLM/SPNEGO/Kerberos tokens into a human readable format.
 
 See [How to Install](#how-to-install) for more details
 
-* CPython 3.6+
+* CPython 3.7+
 * [cryptography](https://github.com/pyca/cryptography)
 
 ### Optional Requirements

--- a/build_helpers/lib.sh
+++ b/build_helpers/lib.sh
@@ -50,8 +50,6 @@ lib::setup::python_requirements() {
         echo "::group::Installing Python Requirements"
     fi
 
-    python -m pip install --upgrade pip setuptools wheel
-
     echo "Installing spnego"
     if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]; then
         DIST_LINK_PATH="$( echo "${PWD}/dist" | sed -e 's/^\///' -e 's/\//\\/g' -e 's/^./\0:/' )"
@@ -59,13 +57,13 @@ lib::setup::python_requirements() {
         DIST_LINK_PATH="${PWD}/dist"
     fi
 
-    python -m pip install pyspnego \
-        --no-index \
+    # Getting the version is important so that pip prioritises our local dist
+    python -m pip install build
+    SPNEGO_VERSION="$( python -c "import build.util; print(build.util.project_wheel_metadata('.').get('Version'))" )"
+
+    python -m pip install pyspnego=="${SPNEGO_VERSION}" \
         --find-links "file://${DIST_LINK_PATH}" \
-        --no-build-isolation \
-        --no-dependencies \
         --verbose
-    python -m pip install pyspnego
 
     echo "Installing dev dependencies"
     python -m pip install -r requirements-test.txt

--- a/build_helpers/run-container.sh
+++ b/build_helpers/run-container.sh
@@ -16,17 +16,17 @@ source ./build_helpers/lib.sh
 lib::setup::system_requirements
 
 apt-get -y install \
-    cython3 \
     locales \
     python3 \
-    python3-{dev,pip,setuptools,virtualenv,wheel}
+    python3-{dev,pip,venv}
 ln -s /usr/bin/python3 /usr/bin/python
 
 # Ensure locale settings in test work
 sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
 dpkg-reconfigure --frontend=noninteractive locales
 
-python setup.py bdist_wheel
+python -m pip install build
+python -m build
 lib::setup::python_requirements
 
 # Ensure we don't pollute the local dir + mypy doesn't like this

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,62 @@
 [build-system]
-requires = ["setuptools>=42.0.0", "wheel"]
+requires = [
+    "Cython >= 0.29.29, < 3.0.0; sys_platform == 'win32'",  # 0.29.29 includes fixes for Python 3.11
+    "setuptools >= 61.0.0",  # Support for setuptools config in pyproject.toml
+]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "pyspnego"
+description = "Windows Negotiate Authentication Client and Server"
+readme = "README.md"
+requires-python = ">=3.7"
+license = {file = "LICENSE"}
+authors = [
+    { name = "Jordan Borean", email = "jborean93@gmail.com" }
+]
+keywords = ["windows", "spnego", "negotiate", "ntlm", "kerberos", "sspi", "gssapi", "auth"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10"
+]
+dependencies = [
+    "cryptography",
+]
+dynamic = ["version"]
+
+[project.optional-dependencies]
+kerberos = [
+    "gssapi >= 1.6.0; sys_platform != 'win32'",
+    "krb5 >= 0.3.0; sys_platform != 'win32'"
+]
+yaml = ["ruamel.yaml"]
+
+[project.scripts]
+pyspnego-parse = "spnego.__main__:main"
+
+[project.urls]
+homepage = "https://github.com/jborean93/pyspnego"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.dynamic]
+version = {attr = "spnego._version.__version__"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+spnego = ["py.types"]
+"spnego._sspi_raw" = ["*.pyi"]
+
+[tool.setuptools.exclude-package-data]
+"spnego._sspi_raw" = ["*.pxd", "*.pyx"]
 
 [tool.black]
 line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -3,54 +3,16 @@
 # Copyright: (c) 2020 Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
-import glob
 import os
 import os.path
 import typing
 
-from setuptools import Extension, find_packages, setup
-from setuptools.command.sdist import sdist
-
-SKIP_CYTHON_FILE = "__dont_use_cython__.txt"
-
-
-def abs_path(rel_path: str) -> str:
-    return os.path.join(os.path.dirname(__file__), rel_path)
-
-
-def get_version(
-    rel_path: str,
-) -> str:
-    with open(abs_path(rel_path), mode="r") as version_fd:
-        for line in version_fd.readlines():
-
-            if line.startswith("__version__"):
-                delim = '"' if '"' in line else "'"
-
-                return line.split(delim)[1]
-
-        else:
-            raise RuntimeError("Unable to find version string.")
-
-
-with open(abs_path("README.md"), mode="rb") as fd:
-    long_description = fd.read().decode("utf-8")
+from setuptools import Extension, setup
 
 extensions = None
 
-if os.name == "nt" or os.environ.get("SPNEGO_FORCE_CYTHONIZE", "").lower() == "true":
-    if os.path.exists(SKIP_CYTHON_FILE):
-        print("In distributed package, building from C files...")
-        SOURCE_EXT = "c"
-    else:
-        try:
-            from Cython.Build import cythonize
-
-            print("Building from Cython files...")
-            SOURCE_EXT = "pyx"
-        except ImportError:
-            print("Cython not found, building from C files...")
-            SOURCE_EXT = "c"
+if os.name == "nt":
+    from Cython.Build import cythonize
 
     def build_sspi_extension(
         name: str,
@@ -58,86 +20,23 @@ if os.name == "nt" or os.environ.get("SPNEGO_FORCE_CYTHONIZE", "").lower() == "t
     ) -> Extension:
         rel_path = os.path.join("src", "spnego", "_sspi_raw", name)
 
-        if SOURCE_EXT == "c" and not os.path.exists(abs_path(f"{rel_path}.c")):
-            raise Exception("SSPI C files not found, ensure Cython is installed to generate from source.")
-
         if not isinstance(libraries, list):
             libraries = [libraries]
 
         return Extension(
             name=".".join(rel_path.split(os.path.sep)[1:]),
-            sources=[f"{rel_path}.{SOURCE_EXT}"],
+            sources=[f"{rel_path}.pyx"],
             libraries=libraries,
             define_macros=[("UNICODE", "1"), ("_UNICODE", "1"), ("SECURITY_WIN32", "1")],
         )
 
-    extensions = [
-        build_sspi_extension("sspi", "Secur32"),
-        build_sspi_extension("text", "Kernel32"),
-    ]
-    if SOURCE_EXT == "pyx":
-        extensions = cythonize(extensions, language_level=3)
-
-
-class sdist_spnego(sdist):
-    def run(self) -> None:
-        if not self.dry_run:
-            with open(SKIP_CYTHON_FILE, mode="wb") as flag_file:
-                flag_file.write(b"")
-
-            sdist.run(self)
-
-            os.remove(SKIP_CYTHON_FILE)
-
-
-setup(
-    name="pyspnego",
-    version=get_version(os.path.join("src", "spnego", "_version.py")),
-    packages=find_packages(where="src"),
-    package_data={
-        "spnego": ["py.typed"],
-        "spnego._sspi_raw": ["*.pyi"],
-    },
-    package_dir={"": "src"},
-    entry_points={"console_scripts": ["pyspnego-parse = spnego.__main__:main"]},
-    ext_modules=extensions,
-    zip_safe=False,
-    cmdclass={
-        "sdist": sdist_spnego,
-    },
-    install_requires=[
-        "cryptography",
-    ],
-    extras_require={
-        ':python_version<"3.7"': [
-            "dataclasses",
+    extensions = cythonize(
+        [
+            build_sspi_extension("sspi", "Secur32"),
+            build_sspi_extension("text", "Kernel32"),
         ],
-        'kerberos:sys_platform=="win32"': [],
-        'kerberos:sys_platform!="win32"': [
-            "gssapi>=1.5.0",
-            "krb5>=0.3.0",
-        ],
-        "yaml": [
-            "ruamel.yaml",
-        ],
-    },
-    author="Jordan Borean",
-    author_email="jborean93@gmail.com",
-    url="https://github.com/jborean93/pyspnego",
-    description="Windows Negotiate Authentication Client and Server",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    keywords="windows spnego negotiate ntlm kerberos sspi gssapi auth",
-    license="MIT",
-    python_requires=">=3.6",
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-    ],
-)
+        language_level=3,
+    )
+
+
+setup(ext_modules=extensions)

--- a/src/spnego/_version.py
+++ b/src/spnego/_version.py
@@ -1,4 +1,4 @@
 # Copyright: (c) 2020, Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
-__version__ = "0.5.4"
+__version__ = "0.6.0"

--- a/src/spnego/tls.py
+++ b/src/spnego/tls.py
@@ -97,6 +97,7 @@ def default_tls_context(
 
     # The minimum_version field requires OpenSSL 1.1.0g or newer, fallback to the deprecated method of setting the
     # OP_NO_* options.
+    # FUTURE: Remove once Python 3.10 is minimum which requires 1.1.1 or newer
     tls_version = getattr(ssl, "TLSVersion", None)
     if hasattr(ctx, "minimum_version") and tls_version:
         setattr(ctx, "minimum_version", tls_version.TLSv1_2)

--- a/tests/integration/inventory.yml
+++ b/tests/integration/inventory.yml
@@ -19,8 +19,6 @@ all:
         ansible_connection: psrp
         ansible_port: 5985
         python_interpreters:
-        - C:\Program Files\Python36
-        - C:\Program Files (x86)\Python36-32
         - C:\Program Files\Python37
         - C:\Program Files (x86)\Python37-32
         - C:\Program Files\Python38
@@ -57,7 +55,7 @@ all:
       vars:
         ansible_ssh_common_args: -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
         python_interpreters:
-        - /usr/bin/python3
+        - /usr/bin/python3.8
         python_venv_path: ~/venv
 
   vars:

--- a/tests/integration/main.yml
+++ b/tests/integration/main.yml
@@ -125,12 +125,6 @@
       product_id: '{{ item.product_id }}'
       state: present
     with_items:
-    - url: https://www.python.org/ftp/python/3.6.8/python-3.6.8.exe
-      product_id: '{B56829C6-1C25-469E-B351-1467C6295566}'
-      arguments: /quiet InstallAllUsers=1 Shortcuts=0
-    - url: https://www.python.org/ftp/python/3.6.8/python-3.6.8-amd64.exe
-      product_id: '{E1155302-B578-4D8C-8431-FAE677FBC58C}'
-      arguments: /quiet InstallAllUsers=1 Shortcuts=0
     - url: https://www.python.org/ftp/python/3.7.9/python-3.7.9.exe
       product_id: '{65048DA1-5996-4FF9-B20A-66EB2E68D0A4}'
       arguments: /quiet InstallAllUsers=1 Shortcuts=0
@@ -143,17 +137,17 @@
     - url: https://www.python.org/ftp/python/3.8.10/python-3.8.10-amd64.exe
       product_id: '{080E0048-853C-49FB-96ED-30DEF7AB6E34}'
       arguments: /quiet InstallAllUsers=1 Shortcuts=0
-    - url: https://www.python.org/ftp/python/3.9.7/python-3.9.7.exe
-      product_id: '{E3343646-507D-4269-BF4C-68D78153FD0D}'
+    - url: https://www.python.org/ftp/python/3.9.13/python-3.9.13.exe
+      product_id: '{E23C472D-F346-4D47-A909-9D48E5D7252F}'
       arguments: /quiet InstallAllUsers=1 Shortcuts=0
-    - url: https://www.python.org/ftp/python/3.9.7/python-3.9.7-amd64.exe
-      product_id: '{05903EEF-72A2-4C1A-AD35-41AD6C7094A8}'
+    - url: https://www.python.org/ftp/python/3.9.13/python-3.9.13-amd64.exe
+      product_id: '{90A30DAB-6FD8-4CF8-BB8B-C0DB21C69F20}'
       arguments: /quiet InstallAllUsers=1 Shortcuts=0
-    - url: https://www.python.org/ftp/python/3.10.0/python-3.10.0.exe
-      product_id: '{88B95F8C-ECD7-42F1-A216-0880C9DE2F34}'
+    - url: https://www.python.org/ftp/python/3.10.6/python-3.10.6.exe
+      product_id: '{8B822DC2-4E2B-471A-B26C-6249A722DDB9}'
       arguments: /quiet InstallAllUsers=1 Shortcuts=0
-    - url: https://www.python.org/ftp/python/3.10.0/python-3.10.0-amd64.exe
-      product_id: '{BB3BA776-4C84-43FB-9CE6-5A37FFC23032}'
+    - url: https://www.python.org/ftp/python/3.10.6/python-3.10.6-amd64.exe
+      product_id: '{C3A057F3-209B-4244-9697-D69031B81AAB}'
       arguments: /quiet InstallAllUsers=1 Shortcuts=0
 
   - name: ensure virtualenv package is installed for each Python install
@@ -183,10 +177,31 @@
       src: C:\temp\wheels.zip
       dest: C:\temp\wheels
 
-  - name: install pyspnego wheel into virtualenv
-    win_shell: |
-      &'{{ python_venv_path }}\{{ item | win_basename }}\Scripts\pip.exe' install --no-index --find-links=C:/temp/wheels --no-deps pyspnego
-      &'{{ python_venv_path }}\{{ item | win_basename }}\Scripts\pip.exe' install pyspnego pytest requests
+  - name: get pyspnego artifact sdist filename
+    win_find:
+      paths: C:\temp\wheels
+      patterns: 'pyspnego-*.tar.gz'
+      use_regex: false
+    register: spnego_sdist_file
+
+  - name: verify sdist was found
+    assert:
+      that:
+      - spnego_sdist_file.files | count == 1
+
+  - name: get pyspnego artifact version
+    set_fact:
+      spnego_version: >-
+        {{ spnego_sdist_file.files[0].filename | regex_replace('pyspnego-(?P<version>.*)\.tar\.gz', '\g<version>') }}
+
+  - name: install pyspnego into virtualenv
+    win_command: >-
+      "{{ python_venv_path }}\{{ item | win_basename }}\Scripts\python.exe" -m pip
+      install
+      pyspnego=={{ spnego_version }}
+      pytest
+      requests
+      --find-links=C:/temp/wheels
     args:
       creates: '{{ python_venv_path }}\{{ item | win_basename }}\Lib\site-packages\spnego'
     with_items: '{{ python_interpreters }}'
@@ -251,8 +266,8 @@
       - dnsmasq
       - epel-release
       - gcc
-      - python3
-      - python3-devel
+      - python38
+      - python38-devel
       - unzip
       - vim
       state: present
@@ -266,8 +281,7 @@
     pip:
       name:
       - virtualenv
-      - wheel
-      executable: /usr/bin/pip3
+      executable: /usr/bin/pip3.8
 
   - name: setup NetworkManager to use dnsmasq
     copy:
@@ -377,27 +391,35 @@
       dest: ~/wheels
     become: no
 
-  - name: find the universal wheel
+  - name: get pyspnego artifact sdist filename
     find:
       paths: ~/wheels
-      patterns: pyspnego-*-py2.py3-none-any.whl
+      patterns: 'pyspnego-*.tar.gz'
       recurse: no
       file_type: file
     become: no
-    register: wheel_artifact
+    register: spnego_sdist_file
+
+  - name: verify sdist was found
+    assert:
+      that:
+      - spnego_sdist_file.files | count == 1
+
+  - name: get pyspnego artifact version
+    set_fact:
+      spnego_version: >-
+        {{ spnego_sdist_file.files[0].path | basename | regex_replace('pyspnego-(?P<version>.*)\.tar\.gz', '\g<version>') }}
 
   - name: create a virtualenv for each Python interpeter
     pip:
       name:
-      - gssapi
-      - krb5
       - pytest
       - pytest-forked
       - requests
-      - wheel
-      - '{{ wheel_artifact.files[0].path }}'
+      - pyspnego[kerberos] == {{ spnego_version }}
       virtualenv: '{{ python_venv_path }}/{{ item | basename }}'
       virtualenv_python: '{{ item }}'
+      extra_args: --find-links file:///{{ spnego_sdist_file.files[0].path | dirname }}
     become: no
     with_items: '{{ python_interpreters }}'
 


### PR DESCRIPTION
This takes full advantage of PEP 517 with build time dependencies for the Cython code and mostly read only metadata for the project itself.

Part of this change means the sdist no longer contains the cythonised files and will be automatically cythonised at install time if the wheel is not being used.