### PR TITLE
Ignore GSS_S_NO_CONTEXT on GSSAPI stepping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.1 - TBD
+
+* Ignore `GSS_S_NO_CONTEXT` errors on GSSAPI after stepping through the token exchange before the context is complete
+  * This is raised by MIT krb5 before 1.14.x and can be ignored
+
 ## 0.6.2 - 2022-10-27
 
 * Fix up sdist and wheels to include `py.typed` type annotation marker

--- a/src/spnego/_gss.py
+++ b/src/spnego/_gss.py
@@ -549,7 +549,16 @@ class GSSAPIProxy(ContextProxy):
             log.debug("GSSAPI step input: %s", base64.b64encode(in_token or b"").decode())
 
         out_token = self._context.step(in_token)
-        self._context_attr = int(self._context.actual_flags)
+
+        try:
+            self._context_attr = int(self._context.actual_flags)
+        except gss_errors.MissingContextError:  # pragma: no cover
+            # MIT krb5 before 1.14.x will raise this error if the context isn't
+            # complete. We should only treat it as an error if it happens when
+            # the context is complete (last step).
+            # https://github.com/jborean93/pypsrp/issues/162
+            if self._context.complete:
+                raise
 
         if not self._is_wrapped:
             # When using NTLM through GSSAPI without it being wrapped by SPNEGO

--- a/src/spnego/_gss.py
+++ b/src/spnego/_gss.py
@@ -556,7 +556,7 @@ class GSSAPIProxy(ContextProxy):
             # MIT krb5 before 1.14.x will raise this error if the context isn't
             # complete. We should only treat it as an error if it happens when
             # the context is complete (last step).
-            # https://github.com/jborean93/pypsrp/issues/162
+            # https://github.com/jborean93/pyspnego/issues/55
             if self._context.complete:
                 raise
 

--- a/src/spnego/_version.py
+++ b/src/spnego/_version.py
@@ -1,4 +1,4 @@
 # Copyright: (c) 2020, Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"


### PR DESCRIPTION
Ignores the error GSS_S_NO_CONTEXT when stepping through tokens on GSSAPI. MIT krb5 before 1.14.x raised this error on a context that is incomplete causing an error that can safely be ignored.

Fixes: https://github.com/jborean93/pyspnego/issues/55