### PR TITLE
Add new_context() option to copy a context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   * Server Key Exchange
   * Client Key Exchange
   * Certificate Request
+* Added the `new_context()` method on the context proxies to provide an easy and efficient way to re-use the context credentials and options for a new context
 
 ## 0.6.3 - 2022-11-04
 

--- a/build_helpers/run-container.sh
+++ b/build_helpers/run-container.sh
@@ -10,7 +10,7 @@ docker run \
     --volume "$( pwd )":/tmp/build:z \
     --workdir /tmp/build \
     --env GSSAPI_PROVIDER=${GSSAPI_PROVIDER:-mit} \
-    debian:10 /bin/bash -ex -c 'source /dev/stdin' << 'EOF'
+    debian:11 /bin/bash -ex -c 'source /dev/stdin' << 'EOF'
 
 source ./build_helpers/lib.sh
 lib::setup::system_requirements

--- a/src/spnego/_context.py
+++ b/src/spnego/_context.py
@@ -254,6 +254,8 @@ class ContextProxy(metaclass=abc.ABCMeta):
         if self.protocol not in self.available_protocols(options=options):
             raise ValueError("Protocol %s is not available" % self.protocol)
 
+        self._hostname = hostname
+        self._service = service
         self.spn = None
         if service or hostname:
             self.spn = to_text("%s/%s" % (service if service else "HOST", hostname or "unspecified"))
@@ -390,6 +392,19 @@ class ContextProxy(metaclass=abc.ABCMeta):
 
         Returns:
             bytes: The derived session key from the authenticated context.
+        """
+        pass  # pragma: no cover
+
+    @abc.abstractmethod
+    def new_context(self) -> "ContextProxy":
+        """Creates a new security context.
+
+        Creates a new security context based on the current credential and
+        options of the current context. This is useful when needing to set up a
+        new security context without having to retrieve the credentials again.
+
+        Returns:
+            ContextProxy: The new security context.
         """
         pass  # pragma: no cover
 


### PR DESCRIPTION
Adds the new_context() function that will create a new context based on the existing contexts credentials and options. This is designed to be a more efficient way to recreate a brand new security context. For example it can recreate the context with a cached provider specific credential rather than retrieving a new one for each context. This is important when using Kerberos authentication as the retrieved TGT can be cached and reused across multiple contexts.