### PR TITLE
Remove use of gssntlmssp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v4
-
     - name: build sdist and universal wheel
       run: |
         python -m pip install build
@@ -196,8 +194,6 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v4
-
     - uses: actions/download-artifact@v3
       with:
         name: artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   * Client Key Exchange
   * Certificate Request
 * Added the `new_context()` method on the context proxies to provide an easy and efficient way to re-use the context credentials and options for a new context
+* Removed use of `gssntlmssp` to simplify codebase and ensure a consistent experience across OS versions
+  * Using NTLM on a non-Windows system will use the Python NTLM implementation instead
 
 ## 0.6.3 - 2022-11-04
 

--- a/README.md
+++ b/README.md
@@ -61,24 +61,6 @@ pip install pyspnego[kerberos]
 
 Kerberos also needs to be configured to talk to the domain but that is outside the scope of this page.
 
-While NTLM auth works out of the box, it is recommended to install the
-[gss-ntlmssp](https://github.com/gssapi/gss-ntlmssp) library for full Negotiate support. This can be done with
-
-```bash
-# Debian/Ubuntu
-apt-get install gss-ntlmssp
-
-# Centos/RHEL
-yum install gssntlmssp
-
-# Fedora
-dnf install gssntlmssp
-
-# Arch Linux
-# AUR package https://aur.archlinux.org/packages/gss-ntlmssp/
-```
-
-
 ## How to Use
 
 See [the examples section](docs/examples) for examples on how to use the authentication side of the library.

--- a/src/spnego/_context.py
+++ b/src/spnego/_context.py
@@ -274,11 +274,6 @@ class ContextProxy(metaclass=abc.ABCMeta):
         # Whether the context is wrapped inside another context - set by NegotiateProxy.
         self._is_wrapped = False
 
-        if options & NegotiateOptions.negotiate_kerberos and (
-            self.protocol == "negotiate" and "kerberos" not in self.available_protocols()
-        ):
-            raise FeatureMissingError(NegotiateOptions.negotiate_kerberos)
-
         if options & NegotiateOptions.wrapping_iov and not self.iov_available():
             raise FeatureMissingError(NegotiateOptions.wrapping_iov)
 

--- a/tests/integration/Vagrantfile
+++ b/tests/integration/Vagrantfile
@@ -15,7 +15,10 @@ Vagrant.configure("2") do |config|
         config.vm.define server do |srv|
           srv.vm.box = details['vagrant_box']
           srv.vm.hostname = server
-          srv.vm.network :private_network, ip: details['ansible_host']
+          srv.vm.network :private_network,
+            :ip => details['ansible_host'],
+            :libvirt__network_name => 'spnego-test',
+            :libvirt__domain_name => inventory['all']['vars']['domain_name']
 
           srv.vm.provider :virtualbox do |v|
             v.name = File.basename(File.dirname(__FILE__)) + "_" + server + "_" + Time.now.to_i.to_s

--- a/tests/integration/inventory.yml
+++ b/tests/integration/inventory.yml
@@ -27,6 +27,8 @@ all:
         - C:\Program Files (x86)\Python39-32
         - C:\Program Files\Python310
         - C:\Program Files (x86)\Python310-32
+        - C:\Program Files\Python311
+        - C:\Program Files (x86)\Python311-32
         python_venv_path: C:\temp\venv
         krb_provider: SSPI
 
@@ -38,7 +40,6 @@ all:
               ansible_host: 192.168.65.13
               vagrant_box: centos/stream8
               krb_packages:
-              - gssntlmssp
               - krb5-devel
               - krb5-workstation
               krb_provider: MIT

--- a/tests/integration/main.yml
+++ b/tests/integration/main.yml
@@ -3,24 +3,30 @@
   gather_facts: no
   tasks:
   - name: get network connection for private adapter
-    win_shell: |
-      foreach ($instance in (Get-CimInstance -ClassName Win32_NetworkAdapter -Filter "Netenabled='True'")) {
-          $instance_config = Get-CimInstance -ClassName WIn32_NetworkAdapterConfiguration -Filter "Index = '$($instance.Index)'"
-          if ($instance_config.IPAddress -contains "{{ansible_host}}") {
-              $instance.NetConnectionID
-          }
-      }
-    changed_when: no
+    ansible.windows.win_powershell:
+      parameters:
+        IPAddress: '{{ ansible_host }}'
+      script: |
+        param($IPAddress)
+
+        $Ansible.Changed = $false
+
+        foreach ($instance in (Get-CimInstance -ClassName Win32_NetworkAdapter -Filter "Netenabled='True'")) {
+            $config = Get-CimInstance -ClassName WIn32_NetworkAdapterConfiguration -Filter "Index = '$($instance.Index)'"
+            if ($config.IPAddress -contains $IPAddress) {
+                $instance.NetConnectionID
+            }
+        }
     register: network_connection_name_raw
 
   - name: fail if we didn't get a network connection name
     fail:
       msg: Failed to get the Windows network connection name
-    when: network_connection_name_raw.stdout_lines | count != 1
+    when: network_connection_name_raw.output | count != 1
 
   - name: set fact of network connection name
     set_fact:
-      network_connection_name: '{{ network_connection_name_raw.stdout | trim }}'
+      network_connection_name: '{{ network_connection_name_raw.output[0] }}'
 
 - name: create Domain Controller
   hosts: win_controller
@@ -52,11 +58,6 @@
       groups:
       - Domain Admins
       state: present
-    register: domain_user_result
-    # ADWS may not be online after first reboot, need to keep on retrying
-    retries: 30
-    delay: 15
-    until: domain_user_result is successful
 
   - name: test out domain user that was created
     win_whoami:
@@ -86,18 +87,22 @@
     register: domain_join_result
 
   - name: trust hosts for delegation in AD
-    win_shell: |
-      $computerName = '{{ inventory_hostname }}'
-      $actual = (Get-ADComputer -Identity $computerName -Property TrustedForDelegation).TrustedForDelegation
-      if ($actual) {
-          $false
-      } else {
-          Set-ADComputer -Identity $computerName -TrustedForDelegation $true
-          $true
-      }
+    ansible.windows.win_powershell:
+      parameters:
+        ComputerName: '{{ inventory_hostname }}'
+      script: |
+        param($ComputerName)
+
+        $ErrorActionPreference = 'Stop'
+        $Ansible.Changed = $false
+
+
+        $actual = (Get-ADComputer -Identity $ComputerName -Property TrustedForDelegation).TrustedForDelegation
+        if (-not $actual) {
+            Set-ADComputer -Identity $ComputerName -TrustedForDelegation $true
+            $Ansible.Changed = $true
+        }
     when: inventory_hostname == 'SERVER2022'  # We only want to have this hosted with delegation for testing
-    register: delegate_actual
-    changed_when: delegate_actual.stdout | trim | bool
     delegate_to: '{{ groups["win_controller"][0] }}'
 
   - name: reboot host to finalise domain join
@@ -113,6 +118,19 @@
     vars:
       ansible_become_user: '{{ domain_upn }}'
       ansible_become_pass: '{{ domain_password }}'
+
+# Use the following to get a snaphot of programs installed and their product_ids
+# 'SOFTWARE', 'SOFTWARE\Wow6432Node' | ForEach-Object {
+#       $getParams = @{
+#           Path = "HKLM:\$_\Microsoft\Windows\CurrentVersion\Uninstall\*"
+#           Name = 'DisplayName'
+#           ErrorAction = 'SilentlyContinue'
+#       }
+#       Get-ItemProperty @getParams | Select-Object -Property @(
+#           @{ N = 'Name'; E = { $_.DisplayName } },
+#           @{ N = 'AppId'; E = { $_.PSChildName } }
+#       )
+#   } | Where-Object { $_.Name -like 'Python * Standard Library *' }
 
 - name: set up Python interpreters on test Windows host
   hosts: SERVER2012R2
@@ -143,11 +161,17 @@
     - url: https://www.python.org/ftp/python/3.9.13/python-3.9.13-amd64.exe
       product_id: '{90A30DAB-6FD8-4CF8-BB8B-C0DB21C69F20}'
       arguments: /quiet InstallAllUsers=1 Shortcuts=0
-    - url: https://www.python.org/ftp/python/3.10.6/python-3.10.6.exe
-      product_id: '{8B822DC2-4E2B-471A-B26C-6249A722DDB9}'
+    - url: https://www.python.org/ftp/python/3.10.9/python-3.10.9.exe
+      product_id: '{335CD0FB-50DC-44D2-80E3-39749356F8D6}'
       arguments: /quiet InstallAllUsers=1 Shortcuts=0
-    - url: https://www.python.org/ftp/python/3.10.6/python-3.10.6-amd64.exe
-      product_id: '{C3A057F3-209B-4244-9697-D69031B81AAB}'
+    - url: https://www.python.org/ftp/python/3.10.9/python-3.10.9-amd64.exe
+      product_id: '{0CBB496F-1D15-42F1-AA45-C01C95196EC8}'
+      arguments: /quiet InstallAllUsers=1 Shortcuts=0
+    - url: https://www.python.org/ftp/python/3.11.1/python-3.11.1.exe
+      product_id: '{E5CB3216-2C88-4E4B-ADCA-56E9BAEE7404}'
+      arguments: /quiet InstallAllUsers=1 Shortcuts=0
+    - url: https://www.python.org/ftp/python/3.11.1/python-3.11.1-amd64.exe
+      product_id: '{21EEFB31-6A96-4CAE-9A3B-B7FD6374C155}'
       arguments: /quiet InstallAllUsers=1 Shortcuts=0
 
   - name: ensure virtualenv package is installed for each Python install
@@ -220,28 +244,28 @@
   gather_facts: no
   tasks:
   - name: set WinRM Cbt value to Strict
-    win_shell: |
-      $val = (Get-Item -LiteralPath WSMan:\localhost\Service\Auth\CbtHardeningLevel).Value
-      if ($val -eq 'Strict') {
-          $false
-      } else {
-          Set-Item -LiteralPath WSMan:\localhost\Service\Auth\CbtHardeningLevel -Value Strict
-          $true
-      }
-    register: cbt_res
-    changed_when: cbt_res.stdout | trim | bool
+    ansible.windows.win_powershell:
+      script: |
+        $ErrorActionPreference = 'Stop'
+        $Ansible.Changed = $false
+
+        $val = (Get-Item -LiteralPath WSMan:\localhost\Service\Auth\CbtHardeningLevel).Value
+        if ($val -ne 'Strict') {
+            Set-Item -LiteralPath WSMan:\localhost\Service\Auth\CbtHardeningLevel -Value Strict
+            $Ansible.Changed = $true
+        }
 
   - name: enable WSMan CredSSP Server
-    win_shell: |
-      $val = (Get-Item -LiteralPath WSMan:\localhost\Service\Auth\CredSSP).Value
-      if ($val -eq 'true') {
-          $false
-      } else {
-          $null = Enable-WSManCredSSP -Role Server
-          $true
-      }
-    register: credssp_res
-    changed_when: credssp_res.stdout | trim | bool
+    ansible.windows.win_powershell:
+      script: |
+        $ErrorActionPreference = 'Stop'
+        $Ansible.Changed = $false
+
+        $val = (Get-Item -LiteralPath WSMan:\localhost\Service\Auth\CredSSP).Value
+        if ($val -ne 'true') {
+            $null = Enable-WSManCredSSP -Role Server
+            $Ansible.Changed = $true
+        }
 
   - name: allow SMB traffic in
     win_firewall_rule:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -17,7 +17,7 @@ WinError = exceptions.WinError
     [
         (
             exceptions.NegotiateOptions.negotiate_kerberos,
-            "The Python gssapi library is not installed so Kerberos cannot " "be negotiated.",
+            "The Python gssapi library is not installed so Kerberos cannot be negotiated.",
         ),
         (
             exceptions.NegotiateOptions.wrapping_iov,
@@ -26,7 +26,7 @@ WinError = exceptions.WinError
         ),
         (
             exceptions.NegotiateOptions.wrapping_winrm,
-            "The system is missing the GSSAPI IOV extension headers required " "for WinRM encryption with Kerberos.",
+            "The system is missing the GSSAPI IOV extension headers required for WinRM encryption with Kerberos.",
         ),
         (exceptions.NegotiateOptions.session_key, "The protocol selected does not support getting the session key."),
     ],

--- a/tests/test_gss.py
+++ b/tests/test_gss.py
@@ -100,20 +100,6 @@ def test_no_gssapi_library(monkeypatch):
 
 
 @pytest.mark.skipif(not spnego._gss.HAS_GSSAPI, reason="Requires the gssapi library to be installed for testing")
-def test_gssapi_no_kerberos(monkeypatch):
-    def available_protocols(*args, **kwargs):
-        return ["negotiate", "ntlm"]
-
-    monkeypatch.setattr(spnego._gss, "HAS_GSSAPI", True)
-    monkeypatch.setattr(spnego._gss, "_available_protocols", available_protocols)
-
-    with pytest.raises(
-        FeatureMissingError, match="The Python gssapi library is not installed so Kerberos cannot be " "negotiated."
-    ):
-        spnego._gss.GSSAPIProxy(None, None, options=spnego.NegotiateOptions.negotiate_kerberos)
-
-
-@pytest.mark.skipif(not spnego._gss.HAS_GSSAPI, reason="Requires the gssapi library to be installed for testing")
 def test_gssapi_no_valid_acceptor_cred():
     server_creds: typing.List[typing.Tuple[spnego.Credential, str]] = [
         (spnego.KerberosCCache("ccache"), "kerberos"),


### PR DESCRIPTION
Removes the use of gssntlmssp through the GSSAPIProxy provider. This simplifies the codebase as now it just needs to deal with Kerberos and different gssntlmssp versions that might be installed.