### PR TITLE
Add no_integrity support and bindings in step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ ENV/
 
 # Integration test files
 tests/integration/artifact.zip
+tests/integration/cert_setup
 tests/integration/*.keytab
 tests/integration/.vagrant
 tests/integration/*.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.8.0 - TBD
+
+* Added the `spnego.ContextReq.no_integrity` flag to disable integrity/confidentiality on Kerberos/Negotiate contexts
+  * This is used by authentication contexts that need to disable integrity/confidentiality explicitly
+  * An example would be the LDAP SASL `GSS-SPNEGO` where the context flags control the SSF flags
+* Added optional kwargs to `step()` on a security context `channel_bindings`
+  * This can be used to supply the channel bindings when performing a context step rather than when creating the context
+
 ## 0.7.0 - 2022-12-19
 
 * Added support for decoding the following TLS payloads with `python -m spnego --token ...`

--- a/src/spnego/_context.py
+++ b/src/spnego/_context.py
@@ -127,6 +127,10 @@ class ContextReq(enum.IntFlag):
     # Requires newer python-gssapi version to support https://github.com/pythongssapi/python-gssapi/pull/218
     delegate_policy = 0x00080000
 
+    # Special flag that disables integrity/confidentiality on Kerberos/Negotiate
+    # This should not be set with integrity or confidentiality.
+    no_integrity = 0x10000000
+
     # mutual_auth | replay_detect | sequence_detect | confidentiality | integrity
     default = 0x00000002 | 0x00000004 | 0x00000008 | 0x00000010 | 0x00000020
 
@@ -404,7 +408,12 @@ class ContextProxy(metaclass=abc.ABCMeta):
         pass  # pragma: no cover
 
     @abc.abstractmethod
-    def step(self, in_token: typing.Optional[bytes] = None) -> typing.Optional[bytes]:
+    def step(
+        self,
+        in_token: typing.Optional[bytes] = None,
+        *,
+        channel_bindings: typing.Optional[GssChannelBindings] = None,
+    ) -> typing.Optional[bytes]:
         """Performs a negotiation step.
 
         This method performs a negotiation step and processes/generates a token. This token should be then sent to the
@@ -420,6 +429,8 @@ class ContextProxy(metaclass=abc.ABCMeta):
 
         Args:
             in_token: The input token to process (or None to process no input token).
+            channel_bindings: Optional channel bindings ot use in this step. Will take priority over channel bindings
+                set in the context if both are specified.
 
         Returns:
             Optional[bytes]: The output token (or None if no output token is generated.

--- a/src/spnego/_credssp.py
+++ b/src/spnego/_credssp.py
@@ -348,7 +348,12 @@ class CredSSPProxy(ContextProxy):
             credssp_negotiate_context=self._auth_context.new_context() if self._auth_context else None,
         )
 
-    def step(self, in_token: typing.Optional[bytes] = None) -> typing.Optional[bytes]:
+    def step(
+        self,
+        in_token: typing.Optional[bytes] = None,
+        *,
+        channel_bindings: typing.Optional[GssChannelBindings] = None,
+    ) -> typing.Optional[bytes]:
         log.debug("CredSSP step input: %s", to_text(base64.b64encode(in_token or b"")))
 
         if self._step_gen is None:

--- a/src/spnego/_ntlm_raw/crypto.py
+++ b/src/spnego/_ntlm_raw/crypto.py
@@ -506,7 +506,7 @@ def sealkey(flags: int, session_key: bytes, usage: str) -> bytes:
         return session_key
 
 
-def signkey(flags: int, session_key: bytes, usage: str) -> typing.Optional[bytes]:
+def signkey(flags: int, session_key: bytes, usage: str) -> bytes:
     """NTLM SIGNKEY function.
 
     The MS-NLMP `SIGNKEY`_ function used to generate the signing keys for a security context.
@@ -543,7 +543,7 @@ def signkey(flags: int, session_key: bytes, usage: str) -> typing.Optional[bytes
         https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/524cdccb-563e-4793-92b0-7bc321fce096
     """
     if flags & NegotiateFlags.extended_session_security == 0:
-        return None
+        return b""
 
     direction = b"client-to-server" if usage == "initiate" else b"server-to-client"
 

--- a/src/spnego/_version.py
+++ b/src/spnego/_version.py
@@ -1,4 +1,4 @@
 # Copyright: (c) 2020, Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/tests/integration/main.yml
+++ b/tests/integration/main.yml
@@ -1,3 +1,25 @@
+- name: setup local configuration and scratch information
+  hosts: localhost
+  gather_facts: no
+
+  tasks:
+  - name: create cert output folder
+    file:
+      path: '{{ playbook_dir }}/cert_setup'
+      state: directory
+
+  - name: create generate_cert script
+    template:
+      src: generate_cert.sh.tmpl
+      dest: '{{ playbook_dir }}/cert_setup/generate_cert.sh'
+      mode: '700'
+
+  - name: generate CA and LDAPS certificates
+    shell: ./generate_cert.sh password
+    args:
+      creates: '{{ playbook_dir }}/cert_setup/complete.txt'
+      chdir: '{{ playbook_dir }}/cert_setup'
+
 - name: get network adapter for each Windows host
   hosts: windows
   gather_facts: no
@@ -27,6 +49,18 @@
   - name: set fact of network connection name
     set_fact:
       network_connection_name: '{{ network_connection_name_raw.output[0] }}'
+
+  - name: copy CA certificate
+    win_copy:
+      src: '{{ playbook_dir }}/cert_setup/ca.pem'
+      dest: C:\Windows\TEMP\ca.pem
+
+  - name: import CA certificate to trusted root CA
+    win_certificate_store:
+      path: C:\Windows\TEMP\ca.pem
+      state: present
+      store_location: LocalMachine
+      store_name: Root
 
 - name: create Domain Controller
   hosts: win_controller
@@ -66,6 +100,36 @@
     become: yes
     become_method: runas
     vars:
+      ansible_become_user: '{{ domain_upn }}'
+      ansible_become_pass: '{{ domain_password }}'
+
+  - name: copy LDAPS certificate
+    win_copy:
+      src: '{{ playbook_dir }}/cert_setup/DC01.pfx'
+      dest: C:\Windows\TEMP\ldaps.pfx
+
+  - name: import LDAPS certificate
+    win_certificate_store:
+      path: C:\Windows\TEMP\ldaps.pfx
+      password: password
+      key_exportable: no
+      key_storage: machine
+      state: present
+      store_type: service
+      store_location: NTDS
+      store_name: My
+    register: ldaps_cert_info
+
+  - name: register LDAPS certificate
+    ansible.windows.win_powershell:
+      script: |
+        $dse = [adsi]'LDAP://localhost/rootDSE'
+        [void]$dse.Properties['renewServerCertificate'].Add(1)
+        $dse.CommitChanges()
+    when: ldaps_cert_info is changed
+    vars:
+      ansible_become: yes
+      ansible_become_method: runas
       ansible_become_user: '{{ domain_upn }}'
       ansible_become_pass: '{{ domain_password }}'
 
@@ -225,6 +289,7 @@
       pyspnego=={{ spnego_version }}
       pytest
       requests
+      https://github.com/jborean93/sansldap/archive/174408ab40e42f9a2d34bc493027e43cc5d31715.zip
       --find-links=C:/temp/wheels
     args:
       creates: '{{ python_venv_path }}\{{ item | win_basename }}\Lib\site-packages\spnego'
@@ -403,6 +468,16 @@
     become: no
     when: krb_provider == 'Heimdal'
 
+  - name: copy across CA cert
+    copy:
+      src: cert_setup/ca.pem
+      dest: /etc/pki/ca-trust/source/anchors/pyspnego.pem
+    register: ca_cert_copy
+
+  - name: register CA cert
+    command: update-ca-trust
+    when: ca_cert_copy is changed
+
   - name: ensure wheel dir exists
     file:
       path: ~/wheels
@@ -440,6 +515,7 @@
       - pytest
       - pytest-forked
       - requests
+      - https://github.com/jborean93/sansldap/archive/174408ab40e42f9a2d34bc493027e43cc5d31715.zip
       - pyspnego[kerberos] == {{ spnego_version }}
       virtualenv: '{{ python_venv_path }}/{{ item | basename }}'
       virtualenv_python: '{{ item }}'

--- a/tests/integration/templates/generate_cert.sh.tmpl
+++ b/tests/integration/templates/generate_cert.sh.tmpl
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -o pipefail -eux
+
+PASSWORD="${1}"
+
+generate () {
+    NAME="${1}"
+    SUBJECT="${2}"
+    KEY="${3}"
+    CA_NAME="${4}"
+    CA_OPTIONS=("-CA" "${CA_NAME}.pem" "-CAkey" "${CA_NAME}.key" "-CAcreateserial")
+
+    cat > openssl.conf << EOL
+distinguished_name = req_distinguished_name
+
+[req_distinguished_name]
+
+[req]
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = DNS:${SUBJECT}
+EOL
+
+    echo "Generating ${NAME} signed cert"
+    openssl req \
+        -new \
+        "-${KEY}" \
+        -subj "/CN=${SUBJECT}" \
+        -newkey rsa:2048 \
+        -keyout "${NAME}.key" \
+        -out "${NAME}.csr" \
+        -config openssl.conf \
+        -reqexts req \
+        -passin pass:"${PASSWORD}" \
+        -passout pass:"${PASSWORD}"
+
+    openssl x509 \
+        -req \
+        -in "${NAME}.csr" \
+        "-${KEY}" \
+        -out "${NAME}.pem" \
+        -days 365 \
+        -extfile openssl.conf \
+        -extensions req \
+        -passin pass:"${PASSWORD}" \
+        ${CA_OPTIONS[@]}
+
+    openssl pkcs12 \
+        -export \
+        -out "${NAME}.pfx" \
+        -inkey "${NAME}.key" \
+        -in "${NAME}.pem" \
+        -passin pass:"${PASSWORD}" \
+        -passout pass:"${PASSWORD}"
+
+    rm openssl.conf
+}
+
+echo "Generating CA certificate"
+openssl genrsa \
+    -aes256 \
+    -out ca.key \
+    -passout pass:"${PASSWORD}"
+
+openssl req \
+    -new \
+    -x509 \
+    -days 365 \
+    -key ca.key \
+    -out ca.pem \
+    -subj "/CN=pyspnego Root" \
+    -passin pass:"${PASSWORD}"
+
+echo "Generating DC01 LDAPS certificate"
+generate DC01 DC01.{{ domain_name }} sha256 ca
+
+touch complete.txt

--- a/tests/integration/templates/test_integration.py.tmpl
+++ b/tests/integration/templates/test_integration.py.tmpl
@@ -9,6 +9,7 @@ import os
 import pytest
 import re
 import requests
+import sansldap
 import socket
 import spnego
 import spnego.channel_bindings
@@ -33,6 +34,8 @@ USERNAME = '{{ domain_upn }}'
 PASSWORD = '{{ domain_password }}'
 HOSTNAME = socket.gethostname()
 HOST_FQDN = '%s.{{ domain_name }}' % HOSTNAME
+WIN_DC = '{{ groups['win_controller'][0] | lower }}.{{ domain_name | lower }}'
+WIN_DC_IP = socket.gethostbyname(WIN_DC)
 WIN_SERVER_UNTRUSTED = '{{ groups["win_children"][0] }}.{{ domain_name }}'  # Not trusted for delegation in AD
 WIN_SERVER_TRUSTED = '{{ groups["win_children"][1] }}.{{ domain_name }}'  # Trusted for delegation in AD
 WIN_SERVER_TRUSTED_IP = socket.gethostbyname(WIN_SERVER_TRUSTED)
@@ -840,3 +843,72 @@ def test_smb_auth():
 
     finally:
         s.close()
+
+
+@pytest.mark.parametrize('protocol', ["kerberos", "negotiate", "negotiate-ntlm", "ntlm"])
+def test_ldap_no_integrity(protocol: str) -> None:
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    context.load_default_certs()
+
+    # Connecting over LDAPS will allow us to test out no_integrity works as
+    # MS LDAP doesn't allow integrity/confidentiality over an existing LDAPS
+    # connection.
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0) as sock:
+        sock.settimeout(10)
+
+        with context.wrap_socket(sock, server_hostname=WIN_DC) as ssock:
+            ssock.connect((WIN_DC, 636))
+
+            auth_kwargs = {
+                "service": "ldap",
+                "context_req": spnego.ContextReq.mutual_auth | spnego.ContextReq.no_integrity,
+            }
+            if protocol == "negotiate-ntlm":
+                auth_kwargs["hostname"] = WIN_DC_IP
+                auth_kwargs["protocol"] = "negotiate"
+            else:
+                auth_kwargs["hostname"] = WIN_DC
+                auth_kwargs["protocol"] = protocol
+
+            if os.name != 'nt' or IS_SYSTEM:
+                c = spnego.client(
+                    USERNAME,
+                    PASSWORD,
+                    **auth_kwargs,
+                )
+
+            else:
+                c = spnego.client(**auth_kwargs)
+
+            ldap = sansldap.LDAPClient()
+
+            in_token = None
+            while not c.complete:
+                token = c.step(in_token=in_token)
+                if not token:
+                    break
+
+                ldap.bind_sasl("GSS-SPNEGO", cred=token)
+                ssock.write(ldap.data_to_send())
+
+                msg = ldap.receive(ssock.recv(4096))[0]
+                assert isinstance(msg, sansldap.BindResponse)
+                if msg.result.result_code not in [
+                    sansldap.LDAPResultCode.SUCCESS,
+                    sansldap.LDAPResultCode.SASL_BIND_IN_PROGRESS
+                ]:
+                    raise Exception(f"Failed to bind: {msg.result.diagnostics_message}")
+
+                in_token = msg.server_sasl_creds
+
+            if msg.result.result_code != sansldap.LDAPResultCode.SUCCESS:
+                raise Exception(f"Failed to bind {msg.result.result_code.name}: {msg.result.diagnostics_message}")
+
+            # LDAP Whoami
+            ldap.extended_request("1.3.6.1.4.1.4203.1.11.3")
+            ssock.write(ldap.data_to_send())
+
+            msg = ldap.receive(ssock.recv(4096))[0]
+            assert isinstance(msg, sansldap.ExtendedResponse)
+            assert msg.value.startswith(b"u:SPNEGO\\")

--- a/tests/integration/tests.yml
+++ b/tests/integration/tests.yml
@@ -5,6 +5,13 @@
   - windows
 
   tasks:
+  - name: template out tests
+    win_template:
+      src: test_integration.py.tmpl
+      dest: C:\temp\test_integration.py
+      block_start_string: '{!!'
+      block_end_string: '!!}'
+
   - name: run integration tests as a normal user account
     win_command: '"{{ python_venv_path }}\{{ item | win_basename }}\Scripts\python.exe" -m pytest C:\temp\test_integration.py -v'
     with_items: '{{ python_interpreters }}'
@@ -28,6 +35,13 @@
   - linux
 
   tasks:
+  - name: template out tests
+    template:
+      src: test_integration.py.tmpl
+      dest: ~/test_integration.py
+      block_start_string: '{!!'
+      block_end_string: '!!}'
+
   - name: run integration tests
     command: '"{{ python_venv_path }}/{{ item | basename }}/bin/python" -m pytest ~/test_integration.py -v --forked'
     with_items: '{{ python_interpreters }}'

--- a/tests/test_gss.py
+++ b/tests/test_gss.py
@@ -11,7 +11,7 @@ import pytest
 import spnego
 import spnego._gss
 import spnego.iov
-from spnego.exceptions import FeatureMissingError, InvalidCredentialError
+from spnego.exceptions import InvalidCredentialError, NoContextError
 
 
 def test_gss_sasl_description_fail(mocker, monkeypatch):
@@ -58,6 +58,62 @@ def test_build_iov_list(kerb_cred):
     assert actual[3] == (spnego.iov.BufferType.header, True, None)
     assert actual[4] == (spnego.iov.BufferType.stream, False, None)
     assert actual[5] == (spnego.iov.BufferType.data, False, b"\x02")
+
+
+def test_gssapi_wrap_no_context(kerb_cred):
+    c = spnego._gss.GSSAPIProxy(kerb_cred.user_princ, protocol="kerberos")
+
+    with pytest.raises(NoContextError, match="Cannot wrap until context has been established"):
+        c.wrap(b"data")
+
+
+def test_gssapi_wrap_iov_no_context(kerb_cred):
+    c = spnego._gss.GSSAPIProxy(kerb_cred.user_princ, protocol="kerberos")
+
+    with pytest.raises(NoContextError, match="Cannot wrap until context has been established"):
+        c.wrap_iov([])
+
+
+def test_gssapi_wrap_winrm_no_context(kerb_cred):
+    c = spnego._gss.GSSAPIProxy(kerb_cred.user_princ, protocol="kerberos")
+
+    with pytest.raises(NoContextError, match="Cannot wrap until context has been established"):
+        c.wrap_winrm(b"data")
+
+
+def test_gssapi_unwrap_no_context(kerb_cred):
+    c = spnego._gss.GSSAPIProxy(kerb_cred.user_princ, protocol="kerberos")
+
+    with pytest.raises(NoContextError, match="Cannot unwrap until context has been established"):
+        c.unwrap(b"data")
+
+
+def test_gssapi_unwrap_iov_no_context(kerb_cred):
+    c = spnego._gss.GSSAPIProxy(kerb_cred.user_princ, protocol="kerberos")
+
+    with pytest.raises(NoContextError, match="Cannot unwrap until context has been established"):
+        c.unwrap_iov([])
+
+
+def test_gssapi_unwrap_winrm_no_context(kerb_cred):
+    c = spnego._gss.GSSAPIProxy(kerb_cred.user_princ, protocol="kerberos")
+
+    with pytest.raises(NoContextError, match="Cannot unwrap until context has been established"):
+        c.unwrap_winrm(b"header", b"data")
+
+
+def test_gssapi_sign_no_context(kerb_cred):
+    c = spnego._gss.GSSAPIProxy(kerb_cred.user_princ, protocol="kerberos")
+
+    with pytest.raises(NoContextError, match="Cannot sign until context has been established"):
+        c.sign(b"data")
+
+
+def test_gssapi_verify_no_context(kerb_cred):
+    c = spnego._gss.GSSAPIProxy(kerb_cred.user_princ, protocol="kerberos")
+
+    with pytest.raises(NoContextError, match="Cannot verify until context has been established"):
+        c.verify(b"data", b"mic")
 
 
 def test_build_iov_list_invalid_tuple(kerb_cred):

--- a/tests/test_ntlm.py
+++ b/tests/test_ntlm.py
@@ -29,6 +29,7 @@ from spnego.exceptions import (
     BadMICError,
     FeatureMissingError,
     InvalidTokenError,
+    NoContextError,
     OperationNotAvailableError,
     SpnegoError,
     UnsupportedQop,
@@ -208,6 +209,32 @@ def test_ntlm_wrap_no_sign_or_seal():
         n.wrap(b"data")
 
 
+def test_ntlm_wrap_no_context():
+    n = ntlm.NTLMProxy("user", "pass")
+    n._context_attr = spnego.ContextReq.confidentiality | spnego.ContextReq.integrity
+    with pytest.raises(NoContextError, match="Cannot wrap until context has been established"):
+        n.wrap(b"data")
+
+
+def test_ntlm_wrap_winrm_no_context():
+    n = ntlm.NTLMProxy("user", "pass")
+    n._context_attr = spnego.ContextReq.confidentiality | spnego.ContextReq.integrity
+    with pytest.raises(NoContextError, match="Cannot wrap until context has been established"):
+        n.wrap_winrm(b"data")
+
+
+def test_ntlm_unwrap_no_context():
+    n = ntlm.NTLMProxy("user", "pass")
+    with pytest.raises(NoContextError, match="Cannot unwrap until context has been established"):
+        n.unwrap(b"data")
+
+
+def test_ntlm_unwrap_winrm_no_context():
+    n = ntlm.NTLMProxy("user", "pass")
+    with pytest.raises(NoContextError, match="Cannot unwrap until context has been established"):
+        n.unwrap_winrm(b"header", b"data")
+
+
 def test_ntlm_wrap_iov_fail():
     n = ntlm.NTLMProxy("user", "pass")
     with pytest.raises(OperationNotAvailableError, match="NTLM does not offer IOV wrapping"):
@@ -224,6 +251,18 @@ def test_ntlm_sign_qop_invalid():
     n = ntlm.NTLMProxy("user", "pass")
     with pytest.raises(UnsupportedQop, match="Unsupported QoP value 1 specified for NTLM"):
         n.sign(b"data", qop=1)
+
+
+def test_ntlm_sign_no_context():
+    n = ntlm.NTLMProxy("user", "pass")
+    with pytest.raises(NoContextError, match="Cannot sign until context has been established"):
+        n.sign(b"data")
+
+
+def test_ntlm_verify_no_context():
+    n = ntlm.NTLMProxy("user", "pass")
+    with pytest.raises(NoContextError, match="Cannot verify until context has been established"):
+        n.verify(b"data", b"mic")
 
 
 def test_ntlm_no_encoding_flags():


### PR DESCRIPTION
Adds the no_integrity flag which can be used to explicitly tell the underlying provider that integrity and confidentiality is not to be used. This is used for Kerberos authentication on both SSPI and GSSAPI as by default it will always negotiate both integrity and confidentiality even if not explicitly requested.

This commit also adds support for specifying the channel binding token during the step calls. This makes it easier to create a security context and only provide connection level details when the first step is required.