### PR TITLE
Set NTLM Negotiate Version field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.9.1 - 2023-06-14
+
+* Always set the `NTLMSSP_REQUEST_VERSION` flag on the NTLM `Negotiate` message
+  * This aligns the behaviour with how SSPI generates this message
+
 ## 0.9.0 - 2023-04-29
 
 * Added the `spnego.ContextReq.dce_style` flag to enable DCE authentication mode

--- a/src/spnego/_ntlm.py
+++ b/src/spnego/_ntlm.py
@@ -419,7 +419,11 @@ class NTLMProxy(ContextProxy):
         channel_bindings: typing.Optional[GssChannelBindings] = None,
     ) -> bytes:
         if not self._temp_negotiate:
-            self._temp_negotiate = Negotiate(self._context_req)
+            # SSPI always sends the version even if it's optional. There have
+            # been reports that some NTLM servers expect this to produce a
+            # valid challenge/authentication token later in the exchange.
+            # https://github.com/jborean93/smbprotocol/issues/216
+            self._temp_negotiate = Negotiate(self._context_req, version=Version.get_current())
             return self._temp_negotiate.pack()
 
         in_token = in_token or b""

--- a/src/spnego/_version.py
+++ b/src/spnego/_version.py
@@ -1,4 +1,4 @@
 # Copyright: (c) 2020, Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"


### PR DESCRIPTION
Always set the NTLM Negotiate version flag and field when generating the message. This aligns the client behaviour to match with SSPI which also sets this value. It should improve compatibility with some NTLM servers which expect the version flag to be set in subsequent token exchanges.

Fixes: https://github.com/jborean93/smbprotocol/issues/216