### PR TITLE
Rename sspi dep to sspic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.10.0 - 2023-09-27
+## 0.10.1 - 2023-09-29
+
+* Rename `sspi` package dependency to `sspic` to avoid conflicts with pywin32
+
+## 0.10.0 - 2023-09-27 - Has been yanked
 
 * Drop support for Python 3.7 - new minimum is 3.8+
 * Moved SSPI bindings out into a separate package called `sspi`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "cryptography",
-    "sspi >= 0.1.0; sys_platform == 'win32'"
+    "sspic >= 0.1.0; sys_platform == 'win32'"
 ]
 dynamic = ["version"]
 
@@ -122,7 +122,7 @@ module = "spnego._sspi"
 disallow_any_unimported = false
 
 [[tool.mypy.overrides]]
-module = "sspi.*"
+module = "sspic.*"
 ignore_missing_imports = true
 
 # These types are used in tests, too much effort to create stubs

--- a/tests/test_sspi.py
+++ b/tests/test_sspi.py
@@ -58,7 +58,7 @@ def test_build_iov_list_fail_auto_alloc(ntlm_cred):
 def test_no_sspi_library(monkeypatch):
     monkeypatch.setattr(spnego._sspi, "HAS_SSPI", False)
 
-    with pytest.raises(ImportError, match="SSPIProxy requires the Windows only sspi python package"):
+    with pytest.raises(ImportError, match="SSPIProxy requires the Windows only sspic python package"):
         spnego._sspi.SSPIProxy()
 
 


### PR DESCRIPTION
Renames the sspi dependency to sspic to reflect the name change. This was done to avoid a conflict with pywin32's sspi package that it exports.