### PR TITLE
Fix handling of empty passwords

### DIFF
--- a/src/spnego/_credential.py
+++ b/src/spnego/_credential.py
@@ -259,7 +259,7 @@ def unify_credentials(
     """
     if username:
         if isinstance(username, str):
-            if not password:
+            if password is None:
                 username = [CredentialCache(username=username)]
             elif is_ntlm_hash(password):
                 lm, nt = password.split(":", 1)


### PR DESCRIPTION
This is a fix for NTLM authentication for user account with no password. We encountered this regression in pywinrm after requests-ntlm was updated to 1.2.0.