### PR TITLE
Add support for gMSA/machine passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.10.3 - TBD
+
+* Support input password string encoded with the `surrogatepass` error option
+  * This allows the caller to provide a password for a gMSA or machine account that could contain invalid surrogate pairs for both NTLM and Kerberos auth.
+
 ## 0.10.2 - 2023-10-04
 
 * Another rename of the `sspi` package dependency to `sspilib`

--- a/src/spnego/_ntlm_raw/crypto.py
+++ b/src/spnego/_ntlm_raw/crypto.py
@@ -331,7 +331,7 @@ def lmowfv1(password: str) -> bytes:
     # Fix the password to upper case and pad the length to exactly 14 bytes. While it is true LM only authentication
     # will fail if the password exceeds 14 bytes typically it is used in conjunction with the NTv1 hash which has no
     # such restrictions.
-    b_password = password.upper().encode("utf-8").ljust(14, b"\x00")[:14]
+    b_password = password.upper().encode("utf-8", errors="surrogatepass").ljust(14, b"\x00")[:14]
 
     b_hash = io.BytesIO()
     for start, end in [(0, 7), (7, 14)]:
@@ -366,7 +366,7 @@ def ntowfv1(password: str) -> bytes:
     if is_ntlm_hash(password):
         return base64.b16decode(password.split(":")[1].upper())
 
-    return md4(password.encode("utf-16-le"))
+    return md4(password.encode("utf-16-le", errors="surrogatepass"))
 
 
 def ntowfv2(username: str, nt_hash: bytes, domain_name: typing.Optional[str]) -> bytes:

--- a/src/spnego/_version.py
+++ b/src/spnego/_version.py
@@ -1,4 +1,4 @@
 # Copyright: (c) 2020, Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
-__version__ = "0.10.2"
+__version__ = "0.10.3"

--- a/tests/test_gss.py
+++ b/tests/test_gss.py
@@ -175,3 +175,27 @@ def test_gssapi_no_valid_acceptor_cred():
 
         with pytest.raises(InvalidCredentialError, match="No applicable credentials available"):
             spnego._gss.GSSAPIProxy(cred, protocol=protocol, usage="accept")
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("", b""),
+        ("foo", b"foo"),
+        ("café", b"caf\xC3\xA9"),
+        (
+            b"\xDD\xBA\xE2\xD9\x12\x53".decode("utf-16-le", errors="surrogatepass"),
+            b"\xEB\xAB\x9D\xEF\xBF\xBD\xE5\x8C\x92",
+        ),
+        (
+            b"\xDD\xBA\xE2\xD9\x12\x53".decode("utf-16-le", errors="replace"),
+            b"\xEB\xAB\x9D\xEF\xBF\xBD\xE5\x8C\x92",
+        ),
+    ],
+)
+def test_encode_password(
+    value: str,
+    expected: bytes,
+) -> None:
+    actual = spnego._gss._encode_kerb_password(value)
+    assert actual == expected


### PR DESCRIPTION
Added support for using gMSA/machine account passwords with the provided string. The string must have been decoded from the raw UTF-16-LE bytes using the surrogatepass handler for this to work.