### PR TITLE
Move away from dep datetime call

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,7 @@
     "python.testing.pytestEnabled": true,
     "[python]": {
         "editor.codeActionsOnSave": {
-            "source.organizeImports": true
+            "source.organizeImports": "explicit"
         },
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Support input password string encoded with the `surrogatepass` error option
   * This allows the caller to provide a password for a gMSA or machine account that could contain invalid surrogate pairs for both NTLM and Kerberos auth.
+* Stop using deprecated `datetime.dateime.utcnow()` for CredSSP acceptor context
 
 ## 0.10.2 - 2023-10-04
 

--- a/src/spnego/tls.py
+++ b/src/spnego/tls.py
@@ -126,7 +126,7 @@ def generate_tls_certificate() -> typing.Tuple[bytes, bytes, bytes]:
     # socket.getfqdn() can block for a few seconds if DNS is not set up properly.
     name = x509.Name([x509.NameAttribute(x509.NameOID.COMMON_NAME, "CREDSSP-%s" % platform.node())])
 
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     cert = (
         x509.CertificateBuilder()
         .subject_name(name)


### PR DESCRIPTION
Python 3.12 deprecated datetime.datetime.utcnow() in favour of datetime.datetime.now(datetime.timezone.utc) to ensure that a non naive dt object was created. This PR moved to the newer syntax where the older one was used.

Fixes: https://github.com/jborean93/pyspnego/issues/78