### PR TITLE
Fix deprecation warning for Cryptography 44.0.0 or newer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,4 +16,3 @@ repos:
     exclude: ^setup.py|build/
     additional_dependencies:
     - ruamel.yaml
-    - types-cryptography

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.1 - TBD
+
+* Import `ARC4` cipher from the new `decrepits` module sub-package, this removes the warning issued in newer versions of the `cryptography` library
+
 ## 0.11.0 - 2024-06-12
 
 * Support input password string encoded with the `surrogatepass` error option

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12"
 ]
 dependencies = [
-    "cryptography",
+    "cryptography >= 43.0.0",
     "sspilib >= 0.1.0; sys_platform == 'win32'"
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12"
 ]
 dependencies = [
-    "cryptography >= 43.0.0",
+    "cryptography",
     "sspilib >= 0.1.0; sys_platform == 'win32'"
 ]
 dynamic = ["version"]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,4 +10,3 @@ pytest-cov
 pytest-mock
 pywin32 ; sys_platform == 'win32'
 ruamel.yaml
-types-cryptography

--- a/src/spnego/_ntlm_raw/crypto.py
+++ b/src/spnego/_ntlm_raw/crypto.py
@@ -20,7 +20,8 @@ import struct
 import typing
 
 from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms
+from cryptography.hazmat.primitives.ciphers import Cipher
+from cryptography.hazmat.decrepit.ciphers import algorithms as deprecated_algorithms
 
 from spnego._ntlm_raw.des import DES
 from spnego._ntlm_raw.md4 import md4
@@ -43,7 +44,7 @@ class RC4Handle:
     def __init__(self, key: bytes) -> None:
         self._key = key
 
-        arc4 = algorithms.ARC4(self._key)
+        arc4 = deprecated_algorithms.ARC4(self._key)
         cipher = Cipher(arc4, mode=None, backend=default_backend())
         self._handle = cipher.encryptor()
 
@@ -53,7 +54,7 @@ class RC4Handle:
 
     def reset(self) -> None:
         """Reset's the cipher stream back to the original state."""
-        arc4 = algorithms.ARC4(self._key)
+        arc4 = deprecated_algorithms.ARC4(self._key)
         cipher = Cipher(arc4, mode=None, backend=default_backend())
         self._handle = cipher.encryptor()
 

--- a/src/spnego/_ntlm_raw/crypto.py
+++ b/src/spnego/_ntlm_raw/crypto.py
@@ -21,7 +21,6 @@ import typing
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher
-from cryptography.hazmat.decrepit.ciphers import algorithms as deprecated_algorithms
 
 from spnego._ntlm_raw.des import DES
 from spnego._ntlm_raw.md4 import md4
@@ -31,6 +30,14 @@ from spnego._ntlm_raw.messages import (
     NTClientChallengeV2,
     TargetInfo,
 )
+
+try:
+    # cryptography 43.0.0 and later moved ARC4 to decrepit
+    from cryptography.hazmat.decrepit.ciphers import algorithms
+except ImportError:
+    from cryptography.hazmat.primitives.ciphers import (  # type: ignore[no-redef]
+        algorithms,
+    )
 
 # A user does not need to specify their actual plaintext password they can specify the LM and NT hash (from lmowfv1 and
 # ntowfv2) in the form 'lm_hash_hex:nt_hash_hex'. This is still considered a plaintext pass as we can use it to build
@@ -44,7 +51,7 @@ class RC4Handle:
     def __init__(self, key: bytes) -> None:
         self._key = key
 
-        arc4 = deprecated_algorithms.ARC4(self._key)
+        arc4 = algorithms.ARC4(self._key)
         cipher = Cipher(arc4, mode=None, backend=default_backend())
         self._handle = cipher.encryptor()
 
@@ -54,7 +61,7 @@ class RC4Handle:
 
     def reset(self) -> None:
         """Reset's the cipher stream back to the original state."""
-        arc4 = deprecated_algorithms.ARC4(self._key)
+        arc4 = algorithms.ARC4(self._key)
         cipher = Cipher(arc4, mode=None, backend=default_backend())
         self._handle = cipher.encryptor()
 

--- a/src/spnego/_version.py
+++ b/src/spnego/_version.py
@@ -1,4 +1,4 @@
 # Copyright: (c) 2020, Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"


### PR DESCRIPTION
Starting with cryptography-44.0.0 the ARC4 cipher was relocated to a module for deprecated ciphers. It needs to be imported from there now.