### PR TITLE
Fix CredSSP acceptor with LibreSSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.11.2 - TBD
+
+* Fix up CredSSP acceptor when running with a LibreSSL based Python install (OpenBSD)
+
 ## 0.11.1 - 2024-07-24
 
 * Import `ARC4` cipher from the new `decrepits` module sub-package, this removes the warning issued in newer versions of the `cryptography` library

--- a/src/spnego/_credssp.py
+++ b/src/spnego/_credssp.py
@@ -534,8 +534,10 @@ class CredSSPProxy(ContextProxy):
                     want_read = True
 
                 # We need to keep on sending the TLS packets until there is nothing left to send.
+                # If we are an acceptor we still need to send an empty token to the initiator.
+                # https://github.com/jborean93/pyspnego/issues/90
                 out_token = self._out_buff.read()
-                if not out_token:
+                if not out_token and self.usage != "accept":
                     break
                 in_token = yield out_token
 

--- a/src/spnego/_version.py
+++ b/src/spnego/_version.py
@@ -1,4 +1,4 @@
 # Copyright: (c) 2020, Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
-__version__ = "0.11.1"
+__version__ = "0.11.2"


### PR DESCRIPTION
Fix up the TLS handshake code when on a LibreSSL based CPython install. While most installs will use OpenSSL it seems like some BSD based ports still patch in LibreSSL which changes some of the TLS packets emitted in a handshake.

Fixes: https://github.com/jborean93/pyspnego/issues/90