### PR TITLE
Add support for Keytabs on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Drop support for Python 3.7 - new minimum is 3.9+
 * Add official support for Python 3.14
 * Fix CredSSP server certificate generation to limit CN name to 64 characters
+* Added support for using the `KerberosKeytab` on SSPI/Windows with Kerberos authentication
+* Added support for specifying credentials for `spnego.server` using the `credentials` kwarg. This currently only works on Windows/SSPI when specifying a keytab credential for the service
 
 ## 0.11.2 - 2024-11-12
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "cryptography",
-    "sspilib >= 0.1.0; sys_platform == 'win32'"
+    "sspilib >= 0.3.0; sys_platform == 'win32'"  # Introduces KeytabCredential
 ]
 dynamic = ["version"]
 
@@ -70,6 +70,7 @@ exclude = '''
   | buck-out
   | build
   | dist
+  | tests/integration/collections
 )/
 '''
 
@@ -77,7 +78,10 @@ exclude = '''
 profile = "black"
 
 [tool.mypy]
-exclude = "build/"
+exclude = [
+    "build/",
+    "tests/integration/collections/",
+]
 mypy_path = "$MYPY_CONFIG_FILE_DIR/src"
 show_error_codes = true
 show_column_numbers = true

--- a/src/spnego/_credential.py
+++ b/src/spnego/_credential.py
@@ -86,24 +86,9 @@ class NTLMHash:
 class KerberosKeytab:
     """Kerberos Keytab Credential.
 
-    Used with :class:`GSSAPIProxy` for Kerberos authentication. It is used to
-    retrieve a Kerberos ticket using a keytab for authentication rather than a
-    password. The keytab value is specified in the form ``TYPE:RESIDUAL`` where
-    the ``TYPE`` supported is down to the installed Kerberos/GSSAPI
-    implementation and ``RESIDUAL`` is a value specific to the type. Common
-    types are:
-
-        FILE: The value is the path to a keytab.
-        MEMORY: The value is a unique identifier to a keytab stored in memory
-            of the current process. It must be resolvable by the linked GSSAPI
-            provider that this library uses.
-
-    There are other ccache types but they are mostly platform or GSSAPI
-    implementation specific.
-
-    .. Note:
-        This only works on Linux, Windows does not have the concept of a
-        keytab.
+    Used with :class:`GSSAPIProxy` or :class:`SSPIProxy` for Kerberos
+    authentication. It is used to retrieve a Kerberos ticket using a keytab for
+    authentication rather than a password.
 
     Attributes:
         keytab: The keytab to use for authentication. The path will not be

--- a/src/spnego/auth.py
+++ b/src/spnego/auth.py
@@ -178,9 +178,15 @@ def server(
     context_req: ContextReq = ContextReq.default,
     protocol: str = "negotiate",
     options: NegotiateOptions = NegotiateOptions.none,
+    *,
+    credentials: typing.Optional[typing.Union[str, Credential, typing.List[Credential]]] = None,
     **kwargs: typing.Any,
 ) -> ContextProxy:
     """Create a server context to be used for authentication.
+
+    It is only possible to specify a credential when running on Windows and
+    using Kerberos either through Negotiate or Kerberos directly. Other
+    platforms and protocols may be supported in the future.
 
     Args:
         hostname: The principal part of the SPN. This is required for Kerberos auth to build the SPN.
@@ -189,11 +195,12 @@ def server(
         context_req: The :class:`spnego.ContextReq` flags to use when setting up the context.
         protocol: The protocol to authenticate with, can be `ntlm`, `kerberos`, `negotiate`, or `credssp`.
         options: The :class:`spnego.NegotiateOptions` that define pyspnego specific options to control the negotiation.
+        credentials: A credential or list or credentials to use with the server auth context.
         kwargs: Optional arguments to pass through to the authentiction context.
 
     Returns:
         ContextProxy: The context proxy for a client.
     """
     return _new_context(
-        None, None, hostname, service, channel_bindings, context_req, protocol, options, "accept", **kwargs
+        credentials, None, hostname, service, channel_bindings, context_req, protocol, options, "accept", **kwargs
     )

--- a/tests/integration/main.yml
+++ b/tests/integration/main.yml
@@ -168,6 +168,80 @@
     become_method: runas
     become_user: SYSTEM
 
+- name: create test keytabs
+  hosts: TESTWIN,linux_children
+  gather_facts: false
+  tasks:
+  - name: create AD principal for host keytabs
+    microsoft.ad.user:
+      name: '{{ inventory_hostname }}_{{ item }}'
+      description: Kerberos principal for {{ inventory_hostname }} {{ item }} keytab
+      password: '{{ domain_password }}'
+      password_never_expires: true
+      update_password: on_create
+      attributes:
+        set:
+          msDS-SupportedEncryptionTypes: 16  # AES256_CTS_HMAC_SHA1_96
+      state: present
+    become: false
+    delegate_to: DC01
+    with_items:
+    - SERV1
+    - serv2
+
+  - name: create service keytabs
+    ansible.windows.win_command: >-
+      ktpass.exe
+      -out C:\temp\{{ inventory_hostname }}-{{ item }}.keytab
+      -princ {{ item }}/{{ inventory_hostname }}.{{ domain_name }}@{{ domain_name | upper }}
+      -mapUser {{ inventory_hostname }}_{{ item }}@{{ domain_name | upper }}
+      +rndpass
+      -mapOp set
+      -crypto AES256-SHA1
+      -ptype KRB5_NT_PRINCIPAL
+    args:
+      creates: C:\temp\{{ inventory_hostname }}-{{ item }}.keytab
+    become: false
+    delegate_to: DC01
+    with_items:
+    - SERV1
+    - serv2
+
+  - name: create user keytab
+    ansible.windows.win_command: >-
+      ktpass.exe
+      -out C:\temp\{{ domain_username }}.keytab
+      -princ {{ domain_upn }}
+      -mapuser {{ domain_upn }}
+      -pass {{ domain_password }}
+      -crypto AES256-SHA1
+      -ptype KRB5_NT_PRINCIPAL
+    args:
+      creates: C:\temp\{{ domain_username }}.keytab
+    become: false
+    delegate_to: DC01
+    run_once: true
+
+  - name: fetch the service keytab
+    ansible.builtin.fetch:
+      src: C:\temp\{{ inventory_hostname }}-{{ item }}.keytab
+      dest: '{{ inventory_hostname }}-{{ item }}.keytab'
+      flat: true
+    become: false
+    delegate_to: DC01
+    with_items:
+    - SERV1
+    - serv2
+
+  - name: fetch the user keytab
+    ansible.builtin.fetch:
+      src: C:\temp\{{ domain_username }}.keytab
+      dest: '{{ domain_username }}.keytab'
+      flat: true
+    become: false
+    delegate_to: DC01
+    run_once: true
+
 - name: join Windows host to domain
   hosts: win_children
   gather_facts: false
@@ -243,7 +317,7 @@
 #       [Version]"$($matches[1]).$($matches[2])"
 #     }
 
-- name: set up Python interpreters on test Windows host
+- name: set up Python interpreters and other test requirements on test Windows host
   hosts: TESTWIN
   gather_facts: false
   tasks:
@@ -353,6 +427,19 @@
       creates: '{{ python_venv_path }}\{{ item | win_basename }}\Lib\site-packages\spnego'
     with_items: '{{ python_interpreters }}'
 
+  - name: copy service keytabs to host
+    ansible.windows.win_copy:
+      src: '{{ inventory_hostname }}-{{ item }}.keytab'
+      dest: C:\temp\{{ item }}.keytab
+    with_items:
+    - SERV1
+    - serv2
+
+  - name: copy user keytab to host
+    ansible.windows.win_copy:
+      src: '{{ domain_username }}.keytab'
+      dest: C:\temp\user.keytab
+
   - name: template out test integration file
     ansible.windows.win_template:
       src: test_integration.py.tmpl
@@ -449,83 +536,19 @@
       src: krb5.conf.tmpl
       dest: /etc/krb5.conf
 
-  - name: create AD principal for Linux keytabs
-    microsoft.ad.user:
-      name: '{{ inventory_hostname }}_{{ item }}'
-      description: Kerberos principal for {{ inventory_hostname }} {{ item }} keytab
-      password: '{{ domain_password }}'
-      password_never_expires: true
-      update_password: on_create
-      attributes:
-        set:
-          msDS-SupportedEncryptionTypes: 16  # AES256_CTS_HMAC_SHA1_96
-      state: present
-    become: false
-    delegate_to: DC01
-    with_items:
-    - HTTP
-    - cifs
-
-  - name: create keytab for Linux hosts
-    ansible.windows.win_command: >-
-      ktpass.exe
-      -out C:\temp\{{ inventory_hostname }}-{{ item }}.keytab
-      -princ {{ item }}/{{ inventory_hostname }}.{{ domain_name }}@{{ domain_name | upper }}
-      -mapUser {{ inventory_hostname }}_{{ item }}@{{ domain_name | upper }}
-      +rndpass
-      -mapOp set
-      -crypto AES256-SHA1
-      -ptype KRB5_NT_PRINCIPAL
-    args:
-      creates: C:\temp\{{ inventory_hostname }}-{{ item }}.keytab
-    become: false
-    delegate_to: DC01
-    with_items:
-    - HTTP
-    - cifs
-
-  - name: fetch the keytab
-    ansible.builtin.fetch:
-      src: C:\temp\{{ inventory_hostname }}-{{ item }}.keytab
-      dest: '{{ inventory_hostname }}-{{ item }}.keytab'
-      flat: true
-    become: false
-    delegate_to: DC01
-    with_items:
-    - HTTP
-    - cifs
-
-  - name: copy keytabs to host
+  - name: copy service keytabs to host
     ansible.builtin.copy:
       src: '{{ inventory_hostname }}-{{ item }}.keytab'
       dest: /etc/{{ item }}.keytab
     with_items:
-    - HTTP
-    - cifs
+    - SERV1
+    - serv2
 
-  - name: create user keytab - MIT
-    ansible.builtin.command: ktutil
-    args:
-      chdir: ~/
-      creates: ~/user.keytab
-      stdin: "addent -password -p {{ domain_upn }} -k 1 -e aes256-cts\n{{ domain_password }}\nwrite_kt user.keytab"
+  - name: copy user keytab to host
+    ansible.builtin.copy:
+      src: '{{ domain_username }}.keytab'
+      dest: ~/user.keytab
     become: false
-    when: krb_provider == 'MIT'
-
-  - name: create user keytab - Heimdal
-    ansible.builtin.command: >-
-      ktutil
-      --keytab=user.keytab
-      add
-      --principal={{ domain_upn }}
-      --kvno=1
-      --enctype=aes256-cts
-      --password={{ domain_password }}
-    args:
-      chdir: ~/
-      creates: ~/user.keytab
-    become: false
-    when: krb_provider == 'Heimdal'
 
   - name: copy across CA cert
     ansible.builtin.copy:

--- a/tests/integration/templates/test_integration.py.tmpl
+++ b/tests/integration/templates/test_integration.py.tmpl
@@ -1308,17 +1308,27 @@ def rpc_get_key(
         return GetKeyRequest.unpack_response(create_key_resp)
 
 
-@pytest.mark.parametrize('service', ['HTTP', 'cifs'])
+@pytest.mark.parametrize('service', ['SERV1', 'serv2'])
 def test_kerberos_authentication(service, monkeypatch):
-    if os.name != 'nt':
-        monkeypatch.setenv('KRB5_KTNAME', '/etc/%s.keytab' % service)
+    server_kwargs = {}
+    if os.name == 'nt':
+        server_kwargs['credentials'] = spnego.KerberosKeytab(keytab=rf"C:\temp\{service}.keytab")
 
+        # SSPI will report the user in the Netlogon form, use PowerShell to convert the UPN to the Netlogon user.
+        pwsh_command = base64.b64encode('''
+$username = '{0}'
+([Security.Principal.NTAccount]$username).Translate(
+[Security.Principal.SecurityIdentifier]
+).Translate([Security.Principal.NTAccount]).Value
+'''.format(USERNAME).encode('utf-16-le')).decode()
+        expected_username = subprocess.Popen(['powershell', '-EncodedCommand', pwsh_command],
+                                            stdout=subprocess.PIPE).communicate()[0].strip().decode()
     else:
-        if not IS_SYSTEM:
-            pytest.skip("Cannot run Kerberos server tests when not running as SYSTEM")
+        monkeypatch.setenv('KRB5_KTNAME', '/etc/%s.keytab' % service)
+        expected_username = USERNAME
 
     c = spnego.client(USERNAME, PASSWORD, hostname=HOST_FQDN, service=service)
-    s = spnego.server()
+    s = spnego.server(**server_kwargs)
 
     in_token = None
     while not c.complete:
@@ -1327,20 +1337,6 @@ def test_kerberos_authentication(service, monkeypatch):
             break
 
         in_token = s.step(out_token)
-
-    if os.name == 'nt':
-        # SSPI will report the user in the Netlogon form, use PowerShell to convert the UPN to the Netlogon user.
-        pwsh_command = base64.b64encode('''
-$username = '{0}'
-([Security.Principal.NTAccount]$username).Translate(
-    [Security.Principal.SecurityIdentifier]
-).Translate([Security.Principal.NTAccount]).Value
-'''.format(USERNAME).encode('utf-16-le')).decode()
-        expected_username = subprocess.Popen(['powershell', '-EncodedCommand', pwsh_command],
-                                             stdout=subprocess.PIPE).communicate()[0].strip().decode()
-
-    else:
-        expected_username = USERNAME
 
     assert s.client_principal == expected_username
     assert s.session_key == c.session_key
@@ -1372,7 +1368,6 @@ $username = '{0}'
     assert c_iov_res.buffers[1].data == plaintext
 
 
-@pytest.mark.skipif(os.name == 'nt', reason='Windows doesnt support keytabs')
 @pytest.mark.parametrize('protocol, set_principal', [
     ('kerberos', False),
     ('kerberos', True),
@@ -1380,19 +1375,39 @@ $username = '{0}'
     ('negotiate', True),
 ])
 def test_kerberos_authentication_with_keytab(protocol, set_principal, monkeypatch):
-    monkeypatch.setenv('KRB5_KTNAME', '/etc/HTTP.keytab')
-
-    auth_kwargs = {}
+    client_kwargs = {}
+    server_kwargs = {}
     if protocol != 'negotiate':
-        auth_kwargs['protocol'] = protocol
+        client_kwargs['protocol'] = protocol
+        server_kwargs['protocol'] = protocol
 
+    client_principal = None
     if set_principal:
-        keytab = spnego.KerberosKeytab(keytab=os.path.expanduser('~/user.keytab'), principal=USERNAME)
-    else:
-        keytab = spnego.KerberosKeytab(keytab=os.path.expanduser('~/user.keytab'))
+        client_principal = USERNAME
+    elif os.name == 'nt':
+        pytest.skip("SSPI requires a principal in the keytab to work")
 
-    c = spnego.client(keytab, hostname=HOST_FQDN, service='HTTP', **auth_kwargs)
-    s = spnego.server(**auth_kwargs)
+    if os.name == 'nt':
+        server_kwargs['credentials'] = spnego.KerberosKeytab(keytab=r'C:\temp\SERV1.keytab')
+        keytab_path = r'C:\temp\user.keytab'
+
+        # SSPI will report the user in the Netlogon form, use PowerShell to convert the UPN to the Netlogon user.
+        pwsh_command = base64.b64encode('''
+$username = '{0}'
+([Security.Principal.NTAccount]$username).Translate(
+    [Security.Principal.SecurityIdentifier]
+).Translate([Security.Principal.NTAccount]).Value
+'''.format(USERNAME).encode('utf-16-le')).decode()
+        expected_username = subprocess.Popen(['powershell', '-EncodedCommand', pwsh_command],
+                                             stdout=subprocess.PIPE).communicate()[0].strip().decode()
+    else:
+        monkeypatch.setenv('KRB5_KTNAME', '/etc/SERV1.keytab')
+        keytab_path = os.path.expanduser('~/user.keytab')
+        expected_username = USERNAME
+
+    keytab = spnego.KerberosKeytab(keytab=keytab_path, principal=client_principal)
+    c = spnego.client(keytab, hostname=HOST_FQDN, service='SERV1', **client_kwargs)
+    s = spnego.server(**server_kwargs)
 
     in_token = None
     while not c.complete:
@@ -1402,7 +1417,7 @@ def test_kerberos_authentication_with_keytab(protocol, set_principal, monkeypatc
 
         in_token = s.step(out_token)
 
-    assert s.client_principal == USERNAME
+    assert s.client_principal == expected_username
     assert s.session_key == c.session_key
     assert c.negotiated_protocol == 'kerberos'
     assert s.negotiated_protocol == 'kerberos'
@@ -1418,7 +1433,7 @@ def test_kerberos_authentication_with_keytab(protocol, set_principal, monkeypatc
 def test_kerberos_authentication_with_cache(protocol, use_cache_cred, monkeypatch, tmp_path):
     cred = None
 
-    monkeypatch.setenv('KRB5_KTNAME', '/etc/HTTP.keytab')
+    monkeypatch.setenv('KRB5_KTNAME', '/etc/SERV1.keytab')
 
     kinit_args = ['kinit']
     config = {}
@@ -1449,7 +1464,7 @@ def test_kerberos_authentication_with_cache(protocol, use_cache_cred, monkeypatc
     if protocol != 'negotiate':
         auth_kwargs['protocol'] = protocol
 
-    c = spnego.client(cred, hostname=HOST_FQDN, service='HTTP', **auth_kwargs)
+    c = spnego.client(cred, hostname=HOST_FQDN, service='SERV1', **auth_kwargs)
     s = spnego.server(**auth_kwargs)
 
     in_token = None

--- a/tests/test_sspi.py
+++ b/tests/test_sspi.py
@@ -86,4 +86,10 @@ def test_sspi_wrap_no_encryption(ntlm_cred):
 @pytest.mark.skipif("ntlm" not in spnego._sspi.SSPIProxy.available_protocols(), reason="Requires SSPI library")
 def test_sspi_no_valid_cred():
     with pytest.raises(InvalidCredentialError, match="No applicable credentials available"):
-        spnego._sspi.SSPIProxy(spnego.KerberosKeytab("user_princ", "ccache"), protocol="kerberos")
+        spnego._sspi.SSPIProxy(spnego.KerberosCCache("ccache", "user_princ"), protocol="kerberos")
+
+
+@pytest.mark.skipif("ntlm" not in spnego._sspi.SSPIProxy.available_protocols(), reason="Requires SSPI library")
+def test_sspi_keytab_without_principal():
+    with pytest.raises(InvalidCredentialError, match="KerberosKeytab for SSPI requires a principal to be set"):
+        spnego._sspi.SSPIProxy(spnego.KerberosKeytab("keytab"), protocol="kerberos")


### PR DESCRIPTION
Adds support for using a keytab on Windows with SSPI. This will only work with Kerberos authentication but it unifies the credential behaviour across the two platforms.

Fixes: https://github.com/jborean93/pyspnego/issues/95