### PR TITLE
Use canonical client principal when initializing kinit ccache

### DIFF
--- a/src/spnego/_gss.py
+++ b/src/spnego/_gss.py
@@ -246,7 +246,7 @@ def _kinit(
         cred = krb5.get_init_creds_password(ctx, princ, init_opt, password=password)
 
     mem_ccache = krb5.cc_new_unique(ctx, b"MEMORY")
-    krb5.cc_initialize(ctx, mem_ccache, princ)
+    krb5.cc_initialize(ctx, mem_ccache, cred.client)
     krb5.cc_store_cred(ctx, mem_ccache, cred)
 
     return _gss_acquire_cred_from_ccache(mem_ccache, None)


### PR DESCRIPTION
_kinit initialized the temporary MEMORY ccache with the requested
principal (from parse_name_flags) rather than the client principal
returned by the KDC. When the KDC canonicalizes the client name 
e.g. AD returning "Administrator" for a requested "administrator" 
the ccache's key name and value of princ disagree on case.

The subsequent service-ticket lookup key using princ fails with
KRB5_CC_NOTFOUND, even though a valid TGT is present.

Seed the ccache with cred.client (the KDC-returned name) so the cache
identity matches the stored credential. This is a no-op against KDCs
that don't canonicalize, since cred.client will still equal the requested name (princ).
Essentially, this should only resolve cases where MSFT AD is treating
principals as case insensitive and returning a differing case principal 
name than what is passed through.

Fixes #103 